### PR TITLE
Registers "CacheRestored" as output variable.

### DIFF
--- a/Tasks/RestoreAndSaveCacheV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/RestoreAndSaveCacheV1/Strings/resources.resjson/en-US/resources.resjson
@@ -10,6 +10,7 @@
   "loc.input.label.feedList": "Feed",
   "loc.input.label.verbosity": "Verbosity",
   "loc.input.help.verbosity": "Specifies the amount of detail displayed in the output.",
+    "loc.outputVariables.description.cacheRestored": "Set to `true` when the cache is successfully restored.",
   "loc.messages.PackagesDownloadedSuccessfully": "Package were downloaded successfully",
   "loc.messages.PackagesFailedToDownload": "Packages failed to download",
   "loc.messages.ConnectingAs": "Connecting to feeds in your Azure Pipelines/TFS project collection as '%s' [%s]",

--- a/Tasks/RestoreAndSaveCacheV1/task.json
+++ b/Tasks/RestoreAndSaveCacheV1/task.json
@@ -58,6 +58,12 @@
             }
         }
     ],
+    "outputVariables": [
+        {
+            "name": "CacheRestored",
+            "description": "Set to `true` when the cache is successfully restored."
+        }
+    ],
     "dataSourceBindings": [
         {
             "target": "feedList",

--- a/Tasks/RestoreAndSaveCacheV1/task.loc.json
+++ b/Tasks/RestoreAndSaveCacheV1/task.loc.json
@@ -58,6 +58,12 @@
       }
     }
   ],
+  "outputVariables": [
+    {
+      "name": "CacheRestored",
+      "description": "ms-resource:loc.outputVariables.description.cacheRestored"
+    }
+  ],
   "dataSourceBindings": [
     {
       "target": "feedList",

--- a/Tasks/RestoreCacheV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/RestoreCacheV1/Strings/resources.resjson/en-US/resources.resjson
@@ -10,6 +10,7 @@
   "loc.input.label.feedList": "Feed",
   "loc.input.label.verbosity": "Verbosity",
   "loc.input.help.verbosity": "Specifies the amount of detail displayed in the output.",
+  "loc.outputVariables.description.cacheRestored": "Set to `true` when the cache is successfully restored.",
   "loc.messages.PackagesDownloadedSuccessfully": "Package were downloaded successfully",
   "loc.messages.PackagesFailedToDownload": "Packages failed to download",
   "loc.messages.ConnectingAs": "Connecting to feeds in your Azure Pipelines/TFS project collection as '%s' [%s]",

--- a/Tasks/RestoreCacheV1/task.json
+++ b/Tasks/RestoreCacheV1/task.json
@@ -58,6 +58,12 @@
             }
         }
     ],
+    "outputVariables": [
+        {
+            "name": "CacheRestored",
+            "description": "Set to `true` when the cache is successfully restored."
+        }
+    ],
     "dataSourceBindings": [
         {
             "target": "feedList",

--- a/Tasks/RestoreCacheV1/task.loc.json
+++ b/Tasks/RestoreCacheV1/task.loc.json
@@ -58,6 +58,12 @@
       }
     }
   ],
+  "outputVariables": [
+    {
+      "name": "CacheRestored",
+      "description": "ms-resource:loc.outputVariables.description.cacheRestored"
+    }
+  ],
   "dataSourceBindings": [
     {
       "target": "feedList",


### PR DESCRIPTION
Adds a UI element for the CacheRestored output variable and enables intellisense in vscode for it.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/azure-pipelines-artifact-caching-tasks/12)
<!-- Reviewable:end -->
