### PR TITLE
Remove cacherestored from outputvariables

### DIFF
--- a/Tasks/RestoreAndSaveCacheV1/task.json
+++ b/Tasks/RestoreAndSaveCacheV1/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 11
+    "Patch": 12
   },
   "instanceNameFormat": "Restore and save artifact based on: $(keyfile)",
   "inputs": [
@@ -62,12 +62,6 @@
         "Error": "Error",
         "Critical": "Citical"
       }
-    }
-  ],
-  "outputVariables": [
-    {
-      "name": "CacheRestored",
-      "description": "Set to `true` when the cache is successfully restored."
     }
   ],
   "dataSourceBindings": [

--- a/Tasks/RestoreAndSaveCacheV1/task.loc.json
+++ b/Tasks/RestoreAndSaveCacheV1/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 10
+    "Patch": 11
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "inputs": [
@@ -64,12 +64,6 @@
         "Error": "Error",
         "Critical": "Citical"
       }
-    }
-  ],
-  "outputVariables": [
-    {
-      "name": "CacheRestored",
-      "description": "Set to `true` when the cache is successfully restored."
     }
   ],
   "dataSourceBindings": [

--- a/Tasks/RestoreCacheV1/task.json
+++ b/Tasks/RestoreCacheV1/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 11
+    "Patch": 12
   },
   "instanceNameFormat": "Restore artifact based on: $(keyfile)",
   "inputs": [
@@ -62,12 +62,6 @@
         "Error": "Error",
         "Critical": "Citical"
       }
-    }
-  ],
-  "outputVariables": [
-    {
-      "name": "CacheRestored",
-      "description": "Set to `true` when the cache is successfully restored."
     }
   ],
   "dataSourceBindings": [

--- a/Tasks/RestoreCacheV1/task.loc.json
+++ b/Tasks/RestoreCacheV1/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 10
+    "Patch": 11
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "inputs": [
@@ -64,12 +64,6 @@
         "Error": "Error",
         "Critical": "Citical"
       }
-    }
-  ],
-  "outputVariables": [
-    {
-      "name": "CacheRestored",
-      "description": "Set to `true` when the cache is successfully restored."
     }
   ],
   "dataSourceBindings": [

--- a/Tasks/SaveCacheV1/task.json
+++ b/Tasks/SaveCacheV1/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 11
+    "Patch": 12
   },
   "instanceNameFormat": "Save artifact based on: $(keyfile)",
   "inputs": [

--- a/Tasks/SaveCacheV1/task.loc.json
+++ b/Tasks/SaveCacheV1/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 10
+    "Patch": 11
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "inputs": [


### PR DESCRIPTION
After `CacheRestored` was set as an output variable, tasks were not able to use it to control execution of other tasks. E.g. `condition: ne(variables['CacheRestored'], 'true')` failed to work.