### PR TITLE
Match dot folders in task

### DIFF
--- a/Tasks/Common/packaging-common/Tests/UniversalMockHelper.ts
+++ b/Tasks/Common/packaging-common/Tests/UniversalMockHelper.ts
@@ -13,24 +13,21 @@ export class UniversalMockHelper {
     private artifactToolCmd: string
   ) {
     this.tmr.setInput("verbosity", "verbose");
-    this.tmr.setInput('feedlist', 'node-package-feed');
+    this.tmr.setInput("feedlist", "node-package-feed");
 
     process.env.AGENT_HOMEDIRECTORY = "/users/home/directory";
     (process.env.BUILD_SOURCESDIRECTORY = "/users/home/sources"),
-    process.env.SYSTEM_SERVERTYPE = "hosted";
+      (process.env.SYSTEM_SERVERTYPE = "hosted");
     process.env.BUILD_DEFINITIONNAME = "build definition 1";
-    (process.env.ENDPOINT_AUTH_SYSTEMVSSCONNECTION =
-        '{"parameters":{"AccessToken":"token"},"scheme":"OAuth"}');
+    process.env.ENDPOINT_AUTH_SYSTEMVSSCONNECTION =
+      '{"parameters":{"AccessToken":"token"},"scheme":"OAuth"}';
     process.env.ENDPOINT_URL_SYSTEMVSSCONNECTION =
       "https://example.visualstudio.com/defaultcollection";
     process.env.SYSTEM_DEFAULTWORKINGDIRECTORY = "/users/home/directory";
     process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI =
       "https://example.visualstudio.com/defaultcollection";
 
-    artMock.registerArtifactToolUtilitiesMock(
-      tmr,
-      this.artifactToolCmd
-    );
+    artMock.registerArtifactToolUtilitiesMock(tmr, this.artifactToolCmd);
     artMock.registerArtifactToolRunnerMock(this.tmr);
     pkgMock.registerLocationHelpersMock(tmr);
   }
@@ -47,9 +44,11 @@ export class UniversalMockHelper {
     if (!service) {
       service = "https://example.visualstudio.com/defaultcollection";
     }
-    console.log(`${
-      this.artifactToolCmd
-    } universal ${command} --feed ${feed} --service ${service} --package-name ${packageName} --package-version ${packageVersion} --path ${path} --patvar UNIVERSAL_${command.toUpperCase()}_PAT --verbosity verbose`);
+    console.log(
+      `${
+        this.artifactToolCmd
+      } universal ${command} --feed ${feed} --service ${service} --package-name ${packageName} --package-version ${packageVersion} --path ${path} --patvar UNIVERSAL_${command.toUpperCase()}_PAT --verbosity verbose`
+    );
     this.answers.exec[
       `${
         this.artifactToolCmd

--- a/Tasks/Common/packaging-common/cache/cacheUtilities.ts
+++ b/Tasks/Common/packaging-common/cache/cacheUtilities.ts
@@ -287,21 +287,10 @@ export class cacheUtilities {
       }
 
       // Construct this list of artifacts to store. These are relative to prevent the full path from
-      const matchOptions: tl.MatchOptions = {
-        dot: true,
-        nocase: true,
-        debug: true
-      };
-
       const searchDirectory =
         tl.getVariable("System.DefaultWorkingDirectory") || process.cwd();
       const allPaths = tl.find(searchDirectory);
-      const matchedPaths: string[] = tl.match(
-        allPaths,
-        targetPatterns,
-        null,
-        matchOptions
-      );
+      const matchedPaths: string[] = tl.match(allPaths, targetPatterns);
 
       const exactMatches = targetPatterns.filter(tp =>
         allPaths.some(p =>

--- a/Tasks/RestoreAndSaveCacheV1/Tests/RestoreCacheCacheMissDotKeyFile.ts
+++ b/Tasks/RestoreAndSaveCacheV1/Tests/RestoreCacheCacheMissDotKeyFile.ts
@@ -7,7 +7,7 @@ import { UniversalMockHelper } from "packaging-common/Tests/UniversalMockHelper"
 const taskPath = path.join(__dirname, "..", "restorecache.js");
 const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
-const hash = "057b9e891c2548f0ed5583b07f7cb08d0a77eba71a37511fb55dbc67e6c0df25";
+const hash = "053a624fd3674f0969897b5c62a6c7debbac2b3a7b368c4e4bd9b583c69614db";
 
 const a: TaskLibAnswers = {
   findMatch: {
@@ -59,8 +59,10 @@ tmr.registerMock("fs", {
         }
   ): string {
     if (path.endsWith(".commit")) {
+      console.log("PATH", path);
+
       const segments = path.split("/");
-      return segments.splice(segments.length - 2).join("/");
+      return segments.splice(segments.length - 1).join("/");
     }
     return fs.readFileSync(path, options);
   },

--- a/Tasks/RestoreAndSaveCacheV1/Tests/RestoreCacheCacheMissDotKeyFile.ts
+++ b/Tasks/RestoreAndSaveCacheV1/Tests/RestoreCacheCacheMissDotKeyFile.ts
@@ -1,0 +1,88 @@
+import * as tmrm from "azure-pipelines-task-lib/mock-run";
+import * as path from "path";
+import * as fs from "fs";
+import { TaskLibAnswers } from "azure-pipelines-task-lib/mock-answer";
+import { UniversalMockHelper } from "packaging-common/Tests/UniversalMockHelper";
+
+const taskPath = path.join(__dirname, "..", "restorecache.js");
+const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+const hash = "057b9e891c2548f0ed5583b07f7cb08d0a77eba71a37511fb55dbc67e6c0df25";
+
+const a: TaskLibAnswers = {
+  findMatch: {
+    ".commit": [".commit"],
+    "**/out-build": ["src/out/out-build"]
+  },
+  rmRF: {
+    "/users/home/directory/tmp_cache": { success: true }
+  },
+  checkPath: {},
+  exec: {},
+  exist: {},
+  which: {}
+};
+
+tmr.setAnswers(a);
+
+const umh: UniversalMockHelper = new UniversalMockHelper(
+  tmr,
+  a,
+  "/users/tmp/ArtifactTool.exe"
+);
+
+umh.mockUniversalCommand(
+  "download",
+  "node-package-feed",
+  "builddefinition1",
+  `1.0.0-${process.platform}-${hash}`,
+  "/users/home/directory/tmp_cache",
+  {
+    code: 1,
+    stdout: "ArtifactTool.exe output",
+    stderr: "Can't find the package "
+  }
+);
+
+tmr.setInput("keyFile", ".commit");
+tmr.setInput("targetFolder", "**/out-build");
+
+// mock a specific module function called in task
+tmr.registerMock("fs", {
+  readFileSync(
+    path: string,
+    options:
+      | string
+      | {
+          encoding: string;
+          flag?: string;
+        }
+  ): string {
+    if (path.endsWith(".commit")) {
+      const segments = path.split("/");
+      return segments.splice(segments.length - 2).join("/");
+    }
+    return fs.readFileSync(path, options);
+  },
+  chmodSync: fs.chmodSync,
+  writeFileSync: fs.writeFileSync,
+  readdirSync: fs.readdirSync,
+  mkdirSync: fs.mkdirSync,
+  copyFileSync: fs.copyFileSync,
+  statSync: fs.statSync,
+  linkSync: fs.linkSync,
+  symlinkSync: fs.symlinkSync
+});
+
+tmr.registerMock("shelljs", {
+  exec(command: string) {
+    console.log(`Mock executing command: ${command}`);
+    return {
+      code: 0,
+      stdout: "shelljs output",
+      stderr: null
+    };
+  }
+});
+
+tmr.run();

--- a/Tasks/RestoreAndSaveCacheV1/Tests/SaveCacheCacheMissDotKeyFile.ts
+++ b/Tasks/RestoreAndSaveCacheV1/Tests/SaveCacheCacheMissDotKeyFile.ts
@@ -1,0 +1,106 @@
+import * as tmrm from "azure-pipelines-task-lib/mock-run";
+import * as path from "path";
+import * as fs from "fs";
+import { TaskLibAnswers } from "azure-pipelines-task-lib/mock-answer";
+import { UniversalMockHelper } from "packaging-common/Tests/UniversalMockHelper";
+
+const taskPath = path.join(__dirname, "..", "savecache.js");
+const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+const hash = "053a624fd3674f0969897b5c62a6c7debbac2b3a7b368c4e4bd9b583c69614db";
+
+// provide answers for task mock
+const a: TaskLibAnswers = {
+  findMatch: {
+    ".commit": [".commit"],
+    "**/out-build": ["src/out/out-build"]
+  },
+  find: {
+    DefaultWorkingDirectory: ["src/out/out-build", ".commit", ".commitfoo/bar"]
+  },
+  rmRF: {
+    "/users/home/DefaultWorkingDirectory/tmp_cache": { success: true },
+    "DefaultWorkingDirectory/tmp_cache": { success: true },
+    '"DefaultWorkingDirectory/tmp_cache"': { success: true }
+  },
+  stats: {
+    "src/out/out-build": {
+      isDirectory() {
+        return true;
+      }
+    }
+  },
+  exist: {
+    "DefaultWorkingDirectory/tmp_cache": true
+  },
+  checkPath: {},
+  exec: {},
+  which: {}
+};
+
+tmr.setAnswers(a);
+
+const umh: UniversalMockHelper = new UniversalMockHelper(
+  tmr,
+  a,
+  "/users/tmp/ArtifactTool.exe"
+);
+
+umh.mockUniversalCommand(
+  "publish",
+  "node-package-feed",
+  "builddefinition1",
+  `1.0.0-${process.platform}-${hash}`,
+  "DefaultWorkingDirectory/tmp_cache",
+  {
+    code: 0,
+    stdout: "ArtifactTool.exe output",
+    stderr: ""
+  }
+);
+
+tmr.setInput("keyFile", ".commit");
+tmr.setInput("targetFolder", "**/out-build");
+
+const key = `${process.platform}-${hash}`.toUpperCase();
+process.env[key] = "false";
+process.env["SYSTEM_DEFAULTWORKINGDIRECTORY"] = "DefaultWorkingDirectory";
+
+// mock a specific module function called in task
+tmr.registerMock("fs", {
+  readFileSync(
+    path: string,
+    options:
+      | string
+      | {
+          encoding: string;
+          flag?: string;
+        }
+  ): string {
+    if (path.endsWith(".commit")) {
+      const segments = path.split("/");
+      return segments.splice(segments.length - 1).join("/");
+    }
+    return fs.readFileSync(path, options);
+  },
+  chmodSync: fs.chmodSync,
+  writeFileSync: fs.writeFileSync,
+  readdirSync: fs.readdirSync,
+  mkdirSync: fs.mkdirSync,
+  copyFileSync: fs.copyFileSync,
+  statSync: fs.statSync,
+  linkSync: fs.linkSync,
+  symlinkSync: fs.symlinkSync
+});
+
+tmr.registerMock("shelljs", {
+  exec(command: string) {
+    console.log(`Mock exec: ${command}`);
+    return {
+      code: 0,
+      stdout: "shelljs output",
+      stderr: null
+    };
+  }
+});
+
+tmr.run();

--- a/Tasks/RestoreAndSaveCacheV1/Tests/SaveCacheCacheMissDotTarget.ts
+++ b/Tasks/RestoreAndSaveCacheV1/Tests/SaveCacheCacheMissDotTarget.ts
@@ -1,0 +1,116 @@
+import * as tmrm from "azure-pipelines-task-lib/mock-run";
+import * as path from "path";
+import * as fs from "fs";
+import { TaskLibAnswers } from "azure-pipelines-task-lib/mock-answer";
+import { UniversalMockHelper } from "packaging-common/Tests/UniversalMockHelper";
+
+const taskPath = path.join(__dirname, "..", "savecache.js");
+const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+const hash = "caa22019107de89a8bbf9efd8a5273b37fa80bfb9c560e0bc349d5afd6df2ddc";
+
+// provide answers for task mock
+const a: TaskLibAnswers = {
+  findMatch: {
+    ".build/commit": [".build/commit"],
+    ".build": [".build"],
+    "**/out-build": ["src/out/out-build"]
+  },
+  find: {
+    DefaultWorkingDirectory: [
+      "src/out/out-build",
+      ".build/commit",
+      ".buildfoo/bar"
+    ]
+  },
+  rmRF: {
+    "/users/home/DefaultWorkingDirectory/tmp_cache": { success: true },
+    "DefaultWorkingDirectory/tmp_cache": { success: true },
+    '"DefaultWorkingDirectory/tmp_cache"': { success: true }
+  },
+  stats: {
+    "src/out/out-build": {
+      isDirectory() {
+        return true;
+      }
+    },
+    ".build": {
+      isDirectory() {
+        return true;
+      }
+    }
+  },
+  exist: {
+    "DefaultWorkingDirectory/tmp_cache": true
+  },
+  checkPath: {},
+  exec: {},
+  which: {}
+};
+
+tmr.setAnswers(a);
+
+const umh: UniversalMockHelper = new UniversalMockHelper(
+  tmr,
+  a,
+  "/users/tmp/ArtifactTool.exe"
+);
+
+umh.mockUniversalCommand(
+  "publish",
+  "node-package-feed",
+  "builddefinition1",
+  `1.0.0-${process.platform}-${hash}`,
+  "DefaultWorkingDirectory/tmp_cache",
+  {
+    code: 0,
+    stdout: "ArtifactTool.exe output",
+    stderr: ""
+  }
+);
+
+tmr.setInput("keyFile", ".build/commit");
+tmr.setInput("targetFolder", ".build, **/out-build");
+
+const key = `${process.platform}-${hash}`.toUpperCase();
+process.env[key] = "false";
+process.env["SYSTEM_DEFAULTWORKINGDIRECTORY"] = "DefaultWorkingDirectory";
+
+// mock a specific module function called in task
+tmr.registerMock("fs", {
+  readFileSync(
+    path: string,
+    options:
+      | string
+      | {
+          encoding: string;
+          flag?: string;
+        }
+  ): string {
+    if (path.endsWith("/commit")) {
+      const segments = path.split("/");
+      return segments.splice(segments.length - 2).join("/");
+    }
+    return fs.readFileSync(path, options);
+  },
+  chmodSync: fs.chmodSync,
+  writeFileSync: fs.writeFileSync,
+  readdirSync: fs.readdirSync,
+  mkdirSync: fs.mkdirSync,
+  copyFileSync: fs.copyFileSync,
+  statSync: fs.statSync,
+  linkSync: fs.linkSync,
+  symlinkSync: fs.symlinkSync
+});
+
+tmr.registerMock("shelljs", {
+  exec(command: string) {
+    console.log(`Mock exec: ${command}`);
+    return {
+      code: 0,
+      stdout: "shelljs output",
+      stderr: null
+    };
+  }
+});
+
+tmr.run();

--- a/Tasks/RestoreAndSaveCacheV1/Tests/_suite.ts
+++ b/Tasks/RestoreAndSaveCacheV1/Tests/_suite.ts
@@ -242,6 +242,37 @@ describe("RestoreCache tests", function() {
     done();
   });
 
+  it("RestoreCache runs successfully if cache miss for dot syntax keyfile", (done: MochaDone) => {
+    const tp = path.join(__dirname, "RestoreCacheCacheMissDotKeyFile.js");
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+    tr.run();
+
+    assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
+
+    assert(
+      tr.stdOutContained("Found key file: .commit"),
+      "should have found keyfile"
+    );
+
+    assert(
+      tr.stdOutContained("ArtifactTool.exe output"),
+      "should have ArtifactTool output"
+    );
+    assert(
+      tr.stdOutContained(`Cache miss:`),
+      "should have output stating cache miss"
+    );
+    assert(tr.succeeded, "should have succeeded");
+    assert.equal(tr.errorIssues.length, 0, "should have no errors");
+    assert(
+      tr.stdOutContained("set CacheRestored=false"),
+      "'CacheRestored' variable should be set to false"
+    );
+
+    done();
+  });
+
   it("RestoreCache handles artifact permissions errors gracefully", (done: MochaDone) => {
     const tp = path.join(__dirname, "RestoreCachePermissionsError.js");
     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
@@ -504,7 +535,28 @@ describe("SaveCache tests", function() {
     done();
   });
 
-  it("SaveCache creates an archive if cache miss for multiple target folder patterns", (done: MochaDone) => {
+  it("SaveCache creates an archive if cache miss for dot syntax keyfile", (done: MochaDone) => {
+    const tp = path.join(__dirname, "SaveCacheCacheMissDotKeyFile.js");
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+    tr.run();
+
+    assert(
+      tr.stdOutContained("Found key file: .commit"),
+      "should have found keyfile '.commit'"
+    );
+
+    assert(
+      tr.stdOutContained("Cache successfully saved"),
+      "should have saved new cache entry"
+    );
+    assert(tr.succeeded, "should have succeeded");
+    assert.equal(tr.errorIssues.length, 0, "should have no errors");
+
+    done();
+  });
+
+  it("SaveCache creates an archive if cache miss for dot target syntax folder patterns", (done: MochaDone) => {
     const tp = path.join(__dirname, "SaveCacheCacheMissDotTarget.js");
     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 

--- a/Tasks/RestoreAndSaveCacheV1/Tests/_suite.ts
+++ b/Tasks/RestoreAndSaveCacheV1/Tests/_suite.ts
@@ -503,4 +503,34 @@ describe("SaveCache tests", function() {
 
     done();
   });
+
+  it("SaveCache creates an archive if cache miss for multiple target folder patterns", (done: MochaDone) => {
+    const tp = path.join(__dirname, "SaveCacheCacheMissDotTarget.js");
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+    tr.run();
+
+    assert(
+      tr.stdOutContained("Found target folder: ../src/out/out-build"),
+      "should match out-build target folders"
+    );
+    assert(
+      tr.stdOutContained("Found target folder: ../.build"),
+      "should match .build target folders"
+    );
+
+    assert(
+      (tr.stdout.match(/Found target folder: /g) || []).length === 2,
+      "should find 2 target folders to cache"
+    );
+
+    assert(
+      tr.stdOutContained("Cache successfully saved"),
+      "should have saved new cache entry"
+    );
+    assert(tr.succeeded, "should have succeeded");
+    assert.equal(tr.errorIssues.length, 0, "should have no errors");
+
+    done();
+  });
 });

--- a/Tasks/RestoreAndSaveCacheV1/package-lock.json
+++ b/Tasks/RestoreAndSaveCacheV1/package-lock.json
@@ -1448,9 +1448,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "11.13.15",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.15.tgz",
-          "integrity": "sha512-x6ypl5Uzly+j23hbxmMzf12Eb4lOhIEqQz0HuczpTUa1KIx1GpbN/o4E3aAED20UoEsdK0wvyY8QcffuWSLDkw=="
+          "version": "11.13.17",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.17.tgz",
+          "integrity": "sha512-7W3kSMa8diVH6s24a8Qrmvwu+vG3ahOC/flMHFdWSdnPYoQI0yPO84h5zOWYXAha2Npn3Pw3SSuQSwBUfaniyQ=="
         },
         "azure-devops-node-api": {
           "version": "6.6.3",

--- a/Tasks/RestoreAndSaveCacheV1/task.json
+++ b/Tasks/RestoreAndSaveCacheV1/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 13
+    "Patch": 14
   },
   "instanceNameFormat": "Restore and save artifact based on: $(keyfile)",
   "inputs": [

--- a/Tasks/RestoreAndSaveCacheV1/task.loc.json
+++ b/Tasks/RestoreAndSaveCacheV1/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 13
+    "Patch": 14
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "inputs": [

--- a/Tasks/RestoreAndSaveCacheV1/task.loc.json
+++ b/Tasks/RestoreAndSaveCacheV1/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 12
+    "Patch": 13
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "inputs": [

--- a/Tasks/RestoreCacheV1/package-lock.json
+++ b/Tasks/RestoreCacheV1/package-lock.json
@@ -266,9 +266,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "11.13.15",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.15.tgz",
-          "integrity": "sha512-x6ypl5Uzly+j23hbxmMzf12Eb4lOhIEqQz0HuczpTUa1KIx1GpbN/o4E3aAED20UoEsdK0wvyY8QcffuWSLDkw=="
+          "version": "11.13.17",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.17.tgz",
+          "integrity": "sha512-7W3kSMa8diVH6s24a8Qrmvwu+vG3ahOC/flMHFdWSdnPYoQI0yPO84h5zOWYXAha2Npn3Pw3SSuQSwBUfaniyQ=="
         },
         "azure-devops-node-api": {
           "version": "6.6.3",

--- a/Tasks/RestoreCacheV1/task.json
+++ b/Tasks/RestoreCacheV1/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 13
+    "Patch": 14
   },
   "instanceNameFormat": "Restore artifact based on: $(keyfile)",
   "inputs": [

--- a/Tasks/RestoreCacheV1/task.loc.json
+++ b/Tasks/RestoreCacheV1/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 13
+    "Patch": 14
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "inputs": [

--- a/Tasks/RestoreCacheV1/task.loc.json
+++ b/Tasks/RestoreCacheV1/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 12
+    "Patch": 13
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "inputs": [

--- a/Tasks/SaveCacheV1/package-lock.json
+++ b/Tasks/SaveCacheV1/package-lock.json
@@ -266,9 +266,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "11.13.15",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.15.tgz",
-          "integrity": "sha512-x6ypl5Uzly+j23hbxmMzf12Eb4lOhIEqQz0HuczpTUa1KIx1GpbN/o4E3aAED20UoEsdK0wvyY8QcffuWSLDkw=="
+          "version": "11.13.17",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.17.tgz",
+          "integrity": "sha512-7W3kSMa8diVH6s24a8Qrmvwu+vG3ahOC/flMHFdWSdnPYoQI0yPO84h5zOWYXAha2Npn3Pw3SSuQSwBUfaniyQ=="
         },
         "azure-devops-node-api": {
           "version": "6.6.3",

--- a/Tasks/SaveCacheV1/task.json
+++ b/Tasks/SaveCacheV1/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 13
+    "Patch": 14
   },
   "instanceNameFormat": "Save artifact based on: $(keyfile)",
   "inputs": [

--- a/Tasks/SaveCacheV1/task.loc.json
+++ b/Tasks/SaveCacheV1/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 13
+    "Patch": 14
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "inputs": [

--- a/Tasks/SaveCacheV1/task.loc.json
+++ b/Tasks/SaveCacheV1/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 12
+    "Patch": 13
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "inputs": [


### PR DESCRIPTION
This addresses an issue where if a targetFolder has a "." in it, it is incorrectly interpreted as a pattern. E.g. A targetFolder of `.build` would not match the directory `.build`, but _would_ match `testbuild`