### PR TITLE
Add DryRun option to RestoreCache

### DIFF
--- a/Tasks/Common/packaging-common/ArtifactToolRunner.ts
+++ b/Tasks/Common/packaging-common/ArtifactToolRunner.ts
@@ -45,8 +45,6 @@ export function runArtifactTool(artifactToolPath: string, command: string[], exe
         return tl.execSync(artifactToolPath, command, execOptions);
     } else {
         fs.chmodSync(artifactToolPath, "755");
-        console.log("TOOL PATH", artifactToolPath);
-        
         if (!execOptions.silent) {
             execOptions.outStream.write(getCommandString(artifactToolPath, command) + os.EOL);
         }

--- a/Tasks/Common/packaging-common/ArtifactToolRunner.ts
+++ b/Tasks/Common/packaging-common/ArtifactToolRunner.ts
@@ -45,7 +45,8 @@ export function runArtifactTool(artifactToolPath: string, command: string[], exe
         return tl.execSync(artifactToolPath, command, execOptions);
     } else {
         fs.chmodSync(artifactToolPath, "755");
-
+        console.log("TOOL PATH", artifactToolPath);
+        
         if (!execOptions.silent) {
             execOptions.outStream.write(getCommandString(artifactToolPath, command) + os.EOL);
         }

--- a/Tasks/Common/packaging-common/Tests/FeedUtilityMockHelper.ts
+++ b/Tasks/Common/packaging-common/Tests/FeedUtilityMockHelper.ts
@@ -1,0 +1,33 @@
+import tmrm = require("azure-pipelines-task-lib/mock-run");
+import Axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+
+export interface IMockResponse {
+  responseCode: number;
+  data?: any;
+}
+
+export function registerFeedUtilityMock(
+  tmr: tmrm.TaskMockRunner,
+  response: IMockResponse
+) {
+  tmr.setInput("feedlist", "node-package-feed");
+  tmr.setInput("verbosity", "verbose");
+
+  process.env.BUILD_DEFINITIONNAME = "build definition";
+  process.env.AGENT_HOMEDIRECTORY = "/users/home/directory";
+  process.env.BUILD_SOURCESDIRECTORY = "/users/home/sources";
+  process.env.SYSTEM_SERVERTYPE = "hosted";
+  process.env.ENDPOINT_AUTH_SYSTEMVSSCONNECTION =
+    '{"parameters":{"AccessToken":"token"},"scheme":"OAuth"}';
+  process.env.ENDPOINT_URL_SYSTEMVSSCONNECTION =
+    "https://example.visualstudio.com/defaultcollection";
+  process.env.SYSTEM_DEFAULTWORKINGDIRECTORY = "/users/home/directory";
+  process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI =
+    "https://example.visualstudio.com/defaultcollection";
+
+  const mock = new MockAdapter(Axios);
+  console.log("mocking this out");
+
+  mock.onAny().reply(response.responseCode, response.data);
+}

--- a/Tasks/Common/packaging-common/cache/cacheUtilities.ts
+++ b/Tasks/Common/packaging-common/cache/cacheUtilities.ts
@@ -68,7 +68,7 @@ export class cacheUtilities {
       
       const output = alias && alias.length > 0 ? `CacheExists-${alias}` : "CacheExists";
       tl.setVariable(output, packageExists ? "true" : "false");
-      tl.setVariable(hash, "false");
+      tl.setVariable(hash, packageExists ? "true" : "false");
 
       return;
     }

--- a/Tasks/Common/packaging-common/cache/cacheUtilities.ts
+++ b/Tasks/Common/packaging-common/cache/cacheUtilities.ts
@@ -64,11 +64,16 @@ export class cacheUtilities {
     const alias = tl.getInput("alias", false);
 
     if (dryRun) {
-      const packageExists = await doesPackageExist(hash);
-      
-      const output = alias && alias.length > 0 ? `CacheExists-${alias}` : "CacheExists";
-      tl.setVariable(output, packageExists ? "true" : "false");
-      tl.setVariable(hash, packageExists ? "true" : "false");
+      try {
+        const packageExists = await doesPackageExist(hash);
+
+        const output =
+          alias && alias.length > 0 ? `CacheExists-${alias}` : "CacheExists";
+        tl.setVariable(output, packageExists ? "true" : "false");
+        tl.setVariable(hash, packageExists ? "true" : "false");
+      } catch (err) {
+        console.log(err);
+      }
 
       return;
     }
@@ -158,7 +163,9 @@ export class cacheUtilities {
     }
 
     try {
-      const { stderr: error } = shell.exec(
+      const {
+        stderr: error
+      } = shell.exec(
         `tar -C "${tarballParentDir}" -czf "${tarballPath}" ${targetFolders
           .map(t => `\"${t}\"`)
           .join(" ")}`,

--- a/Tasks/Common/packaging-common/cache/cacheUtilities.ts
+++ b/Tasks/Common/packaging-common/cache/cacheUtilities.ts
@@ -70,7 +70,7 @@ export class cacheUtilities {
       
       const output = alias && alias.length > 0 ? `CacheExists-${alias}` : "CacheExists";
       tl.setVariable(output, packageExists ? "true" : "false");
-      tl.setVariable(hash, "true");
+      tl.setVariable(hash, "false");
 
       return;
     }

--- a/Tasks/Common/packaging-common/cache/cacheUtilities.ts
+++ b/Tasks/Common/packaging-common/cache/cacheUtilities.ts
@@ -64,8 +64,6 @@ export class cacheUtilities {
     const alias = tl.getInput("alias", false);
 
     if (dryRun) {
-      console.log("DRY RUN", dryRun);
-      
       const packageExists = await doesPackageExist(hash);
       
       const output = alias && alias.length > 0 ? `CacheExists-${alias}` : "CacheExists";

--- a/Tasks/Common/packaging-common/cache/cacheUtilities.ts
+++ b/Tasks/Common/packaging-common/cache/cacheUtilities.ts
@@ -8,6 +8,7 @@ import shell = require("shelljs");
 import tl = require("azure-pipelines-task-lib/task");
 
 import { UniversalPackages } from "./universalPackages";
+import { doesPackageExist } from "./feedUtilities";
 const universalPackages = new UniversalPackages();
 
 const isWin = process.platform === "win32";
@@ -59,10 +60,24 @@ export class cacheUtilities {
       tarballPath = "/" + tarballPath.replace(":", "").replace(/\\/g, "/");
     }
 
+    const dryRun = tl.getBoolInput("dryRun", false);
+    const alias = tl.getInput("alias", false);
+
+    if (dryRun) {
+      console.log("DRY RUN", dryRun);
+      
+      const packageExists = await doesPackageExist(hash);
+      
+      const output = alias && alias.length > 0 ? `CacheExists-${alias}` : "CacheExists";
+      tl.setVariable(output, packageExists ? "true" : "false");
+      tl.setVariable(hash, "true");
+
+      return;
+    }
+
     try {
       const result = await universalPackages.download(hash, tmp_cache);
 
-      const alias = tl.getInput("alias", false);
       const output =
         alias && alias.length > 0 ? `CacheRestored-${alias}` : "CacheRestored";
 

--- a/Tasks/Common/packaging-common/cache/feedUtilities.ts
+++ b/Tasks/Common/packaging-common/cache/feedUtilities.ts
@@ -1,0 +1,51 @@
+import * as pkgLocationUtils from '../locationUtilities';
+import * as tl from 'azure-pipelines-task-lib';
+import Axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
+
+interface IPackage {
+  id: string;
+  name: string;
+  version: string;
+}
+
+export async function doesPackageExist(hash: string): Promise<boolean> {
+  const feedId = tl.getInput('feedList');
+  // Getting package name from hash
+  const packageId = tl
+    .getVariable('Build.DefinitionName')
+    .replace(/\s/g, '')
+    .substring(0, 255)
+    .toLowerCase();
+
+  const version = `1.0.0-${hash}`;
+  const accessToken = pkgLocationUtils.getSystemAccessToken();
+  const collectionUri = process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI;
+
+  let instance: string = '';
+  const legacyRegex = /https:\/\/(\S+).visualstudio.com\S+/g;
+  const newRegex = /https:\/\/dev.azure.com\/(\S+)\//g;
+
+  const legacyUrl = legacyRegex.exec(collectionUri);
+  const newUrl = newRegex.exec(collectionUri);
+
+  if (legacyUrl) {
+    instance = legacyUrl[1];
+  } else if (newUrl) {
+    instance = newUrl[1];
+  }
+
+  const url = `https://pkgs.dev.azure.com/${instance}/_apis/packaging/feeds/${feedId}/upack/packages/${packageId}/versions/${version}?api-version=5.1-preview.1`;
+
+  const config: AxiosRequestConfig = {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: 'application/json'
+    }
+  };
+  try {
+    const result = await Axios.get<IPackage>(url, config);
+    return result.data.version === version;
+  } catch (err) {
+    return false;
+  }
+}

--- a/Tasks/Common/packaging-common/cache/feedUtilities.ts
+++ b/Tasks/Common/packaging-common/cache/feedUtilities.ts
@@ -18,6 +18,8 @@ export async function doesPackageExist(hash: string): Promise<boolean> {
     .toLowerCase();
 
   const version = `1.0.0-${hash}`;
+  console.log(version);
+
   const accessToken = pkgLocationUtils.getSystemAccessToken();
   const collectionUri = process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI;
 
@@ -44,8 +46,12 @@ export async function doesPackageExist(hash: string): Promise<boolean> {
   };
   try {
     const result = await Axios.get<IPackage>(url, config);
+    tl.debug(result.toString());
+
     return result.data.version === version;
   } catch (err) {
+    tl.debug(err.toString());
+
     return false;
   }
 }

--- a/Tasks/Common/packaging-common/cache/feedUtilities.ts
+++ b/Tasks/Common/packaging-common/cache/feedUtilities.ts
@@ -1,6 +1,6 @@
-import * as pkgLocationUtils from '../locationUtilities';
-import * as tl from 'azure-pipelines-task-lib';
-import Axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
+import * as pkgLocationUtils from "../locationUtilities";
+import * as tl from "azure-pipelines-task-lib";
+import Axios, { AxiosRequestConfig } from "axios";
 
 interface IPackage {
   id: string;
@@ -9,11 +9,11 @@ interface IPackage {
 }
 
 export async function doesPackageExist(hash: string): Promise<boolean> {
-  const feedId = tl.getInput('feedList');
+  const feedId = tl.getInput("feedList");
   // Getting package name from hash
   const packageId = tl
-    .getVariable('Build.DefinitionName')
-    .replace(/\s/g, '')
+    .getVariable("Build.DefinitionName")
+    .replace(/\s/g, "")
     .substring(0, 255)
     .toLowerCase();
 
@@ -23,7 +23,7 @@ export async function doesPackageExist(hash: string): Promise<boolean> {
   const accessToken = pkgLocationUtils.getSystemAccessToken();
   const collectionUri = process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI;
 
-  let instance: string = '';
+  let instance: string = "";
   const legacyRegex = /https:\/\/(\S+).visualstudio.com\S+/g;
   const newRegex = /https:\/\/dev.azure.com\/(\S+)\//g;
 
@@ -41,12 +41,13 @@ export async function doesPackageExist(hash: string): Promise<boolean> {
   const config: AxiosRequestConfig = {
     headers: {
       Authorization: `Bearer ${accessToken}`,
-      Accept: 'application/json'
+      Accept: "application/json"
     }
   };
   try {
     const result = await Axios.get<IPackage>(url, config);
-    tl.debug(result.toString());
+
+    tl.debug(JSON.stringify(result.data));
 
     return result.data.version === version;
   } catch (err) {

--- a/Tasks/Common/packaging-common/cache/feedUtilities.ts
+++ b/Tasks/Common/packaging-common/cache/feedUtilities.ts
@@ -34,6 +34,8 @@ export async function doesPackageExist(hash: string): Promise<boolean> {
     instance = legacyUrl[1];
   } else if (newUrl) {
     instance = newUrl[1];
+  } else {
+    throw `Unable to parse collection uri: '${collectionUri}'`;
   }
 
   const url = `https://pkgs.dev.azure.com/${instance}/_apis/packaging/feeds/${feedId}/upack/packages/${packageId}/versions/${version}?api-version=5.1-preview.1`;

--- a/Tasks/Common/packaging-common/cache/feedUtilities.ts
+++ b/Tasks/Common/packaging-common/cache/feedUtilities.ts
@@ -18,8 +18,6 @@ export async function doesPackageExist(hash: string): Promise<boolean> {
     .toLowerCase();
 
   const version = `1.0.0-${hash}`;
-  console.log(version);
-
   const accessToken = pkgLocationUtils.getSystemAccessToken();
   const collectionUri = process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI;
 

--- a/Tasks/Common/packaging-common/cache/universaldownload.ts
+++ b/Tasks/Common/packaging-common/cache/universaldownload.ts
@@ -76,7 +76,7 @@ export async function run(artifactToolPath: string, hash: string, targetFolder: 
                 success: false,
               };
         }
-
+ 
         return {
             toolRan: true,
             success: false,

--- a/Tasks/Common/packaging-common/package-lock.json
+++ b/Tasks/Common/packaging-common/package-lock.json
@@ -40,6 +40,15 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
       "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg=="
     },
+    "axios": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      }
+    },
     "azure-devops-node-api": {
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-6.6.0.tgz",
@@ -130,10 +139,26 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -191,6 +216,11 @@
         "sprintf-js": "1.1.0"
       }
     },
+    "is-buffer": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+    },
     "jsbn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
@@ -246,6 +276,11 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "once": {
       "version": "1.4.0",

--- a/Tasks/Common/packaging-common/package-lock.json
+++ b/Tasks/Common/packaging-common/package-lock.json
@@ -49,6 +49,14 @@
         "is-buffer": "^2.0.2"
       }
     },
+    "axios-mock-adapter": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.17.0.tgz",
+      "integrity": "sha512-q3efmwJUOO4g+wsLNSk9Ps1UlJoF3fQ3FSEe4uEEhkRtu7SoiAVPj8R3Hc/WP55MBTVFzaDP9QkdJhdVhP8A1Q==",
+      "requires": {
+        "deep-equal": "^1.0.1"
+      }
+    },
     "azure-devops-node-api": {
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-6.6.0.tgz",
@@ -147,6 +155,27 @@
         "ms": "2.0.0"
       }
     },
+    "deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.0.tgz",
+      "integrity": "sha512-ZbfWJq/wN1Z273o7mUSjILYqehAktR2NVoSrOukDkU9kg2v/Uv89yU4Cvz8seJeAmtN5oqiefKq8FPuXOboqLw==",
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -165,6 +194,11 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
     "glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -176,6 +210,14 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
       }
     },
     "inflight": {
@@ -216,10 +258,28 @@
         "sprintf-js": "1.1.0"
       }
     },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
+    },
     "is-buffer": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
       "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "requires": {
+        "has": "^1.0.1"
+      }
     },
     "jsbn": {
       "version": "1.1.0",
@@ -282,6 +342,16 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "object-is": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
+      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -311,6 +381,14 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
         "resolve": "^1.1.6"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
+      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+      "requires": {
+        "define-properties": "^1.1.2"
       }
     },
     "resolve": {

--- a/Tasks/Common/packaging-common/package.json
+++ b/Tasks/Common/packaging-common/package.json
@@ -15,6 +15,7 @@
     "@types/ltx": "^2.8.0",
     "@types/node": "^11.13.0",
     "adm-zip": "^0.4.11",
+    "axios": "^0.19.0",
     "azure-devops-node-api": "^6.6.0",
     "azure-pipelines-task-lib": "^2.8.0",
     "azure-pipelines-tool-lib": "^0.12.0",

--- a/Tasks/Common/packaging-common/package.json
+++ b/Tasks/Common/packaging-common/package.json
@@ -16,6 +16,7 @@
     "@types/node": "^11.13.0",
     "adm-zip": "^0.4.11",
     "axios": "^0.19.0",
+    "axios-mock-adapter": "^1.17.0",
     "azure-devops-node-api": "^6.6.0",
     "azure-pipelines-task-lib": "^2.8.0",
     "azure-pipelines-tool-lib": "^0.12.0",

--- a/Tasks/RestoreAndSaveCacheV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/RestoreAndSaveCacheV1/Strings/resources.resjson/en-US/resources.resjson
@@ -9,6 +9,7 @@
   "loc.input.help.targetfolder": "The folder/file or wildcard of items to cache. For example, node projects can cache packages with '**/node_modules, !**/node_modules/**/node_modules'.",
   "loc.input.label.feedList": "Feed",
   "loc.input.label.platformIndependent": "Platform Independent?",
+  "loc.input.label.dryRun": "Dry run",
   "loc.input.label.alias": "Cache alias",
   "loc.input.label.verbosity": "Verbosity",
   "loc.input.help.verbosity": "Specifies the amount of detail displayed in the output.",

--- a/Tasks/RestoreAndSaveCacheV1/Tests/RestoreCacheDryRunCacheExists.ts
+++ b/Tasks/RestoreAndSaveCacheV1/Tests/RestoreCacheDryRunCacheExists.ts
@@ -1,0 +1,71 @@
+import * as tmrm from "azure-pipelines-task-lib/mock-run";
+import * as path from "path";
+import * as fs from "fs";
+import { TaskLibAnswers } from "azure-pipelines-task-lib/mock-answer";
+import { Constants } from "./Constants";
+
+const taskPath = path.join(__dirname, "..", "restorecache.js");
+const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+const a: TaskLibAnswers = {
+  findMatch: {
+    "**/*/yarn.lock": ["src/webapi/yarn.lock", "src/application/yarn.lock"],
+    "**/*/node_modules": []
+  },
+  rmRF: {
+    "/users/home/directory/tmp_cache": { success: true }
+  },
+  checkPath: {},
+  exec: {},
+  exist: {},
+  which: {}
+};
+
+tmr.setAnswers(a);
+
+tmr.setInput("keyFile", "**/*/yarn.lock");
+tmr.setInput("targetFolders", "**/*/node_modules");
+tmr.setInput("dryRun", "true");
+tmr.setInput("feedlist", "node-package-feed");
+tmr.setInput("verbosity", "verbose");
+
+process.env.BUILD_DEFINITIONNAME = "test build definition";
+process.env.AGENT_HOMEDIRECTORY = "/users/home/directory";
+process.env.BUILD_SOURCESDIRECTORY = "/users/home/sources";
+process.env.SYSTEM_SERVERTYPE = "hosted";
+process.env.ENDPOINT_AUTH_SYSTEMVSSCONNECTION =
+  '{"parameters":{"AccessToken":"token"},"scheme":"OAuth"}';
+process.env.ENDPOINT_URL_SYSTEMVSSCONNECTION =
+  "https://example.visualstudio.com/defaultcollection";
+process.env.SYSTEM_DEFAULTWORKINGDIRECTORY = "/users/home/directory";
+process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI =
+  "https://example.visualstudio.com/defaultcollection";
+
+// mock a specific module function called in task
+tmr.registerMock("fs", {
+  readFileSync(
+    path: string,
+    options:
+      | string
+      | {
+          encoding: string;
+          flag?: string;
+        }
+  ): string {
+    if (path.endsWith("/yarn.lock")) {
+      const segments = path.split("/");
+      return segments.splice(segments.length - 3).join("/");
+    }
+    return fs.readFileSync(path, options);
+  },
+  chmodSync: fs.chmodSync,
+  writeFileSync: fs.writeFileSync,
+  readdirSync: fs.readdirSync,
+  mkdirSync: fs.mkdirSync,
+  copyFileSync: fs.copyFileSync,
+  statSync: fs.statSync,
+  linkSync: fs.linkSync,
+  symlinkSync: fs.symlinkSync
+});
+
+tmr.run();

--- a/Tasks/RestoreAndSaveCacheV1/Tests/RestoreCacheDryRunCacheNotExists.ts
+++ b/Tasks/RestoreAndSaveCacheV1/Tests/RestoreCacheDryRunCacheNotExists.ts
@@ -1,7 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as tmrm from "azure-pipelines-task-lib/mock-run";
-import { Constants } from "./Constants";
 import {
   registerFeedUtilityMock,
   IMockResponse
@@ -31,12 +30,7 @@ tmr.setInput("targetFolders", "**/*/node_modules");
 tmr.setInput("dryRun", "true");
 
 const response: IMockResponse = {
-  responseCode: 200,
-  data: {
-    id: "1234-5678-90123-45678",
-    name: "builddefinition",
-    version: `1.0.0-${process.platform}-${Constants.Hash}`
-  }
+  responseCode: 404
 };
 
 registerFeedUtilityMock(tmr, response);

--- a/Tasks/RestoreAndSaveCacheV1/Tests/_suite.ts
+++ b/Tasks/RestoreAndSaveCacheV1/Tests/_suite.ts
@@ -1,580 +1,543 @@
 import * as path from "path";
 import * as assert from "assert";
 import * as ttm from "azure-pipelines-task-lib/mock-test";
-import { platform } from "os";
 import { Constants } from "./Constants";
 
 before(function() {
   this.timeout(5000);
 });
 
-// describe("RestoreCache tests", function() {
-//   before(function() {
-//     process.env["SYSTEM_PULLREQUEST_ISFORK"] = "false";
-//   });
-
-//   after(() => {});
-
-//   it("RestoreCache runs successfully with warnings if no key files are found", function(done: MochaDone) {
-//     const tp = path.join(__dirname, "RestoreCacheNoKeyFiles.js");
-//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-//     tr.run();
-
-//     assert.equal(tr.succeeded, true, "should have succeeded");
-//     assert.equal(
-//       tr.warningIssues.length > 0,
-//       true,
-//       "should have warnings from key file"
-//     );
-//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
-//     assert.equal(
-//       tr.stdout.indexOf("no key files matching:") >= 0,
-//       true,
-//       "should display 'no key files matching:'"
-//     );
-
-//     done();
-//   });
-
-//   it("RestoreCache is skipped if run from repository fork", function(done: MochaDone) {
-//     const tp = path.join(__dirname, "RestoreCacheFromFork.js");
-//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-//     tr.run();
-
-//     assert.equal(tr.succeeded, true, "should have succeeded");
-//     assert.equal(tr.warningIssues.length, 0, "should have no warnings");
-//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
-//     assert.equal(
-//       tr.stdout.indexOf("result=Skipped;") >= 0,
-//       true,
-//       "task result should be: 'Skipped'"
-//     );
-//     assert.equal(
-//       tr.stdout.indexOf("Caches are not restored for forked repositories.") >=
-//         0,
-//       true,
-//       "should display 'Caches are not restored for forked repositories.'"
-//     );
-
-//     done();
-//   });
-
-//   it("RestoreCache runs successfully if cache hit", (done: MochaDone) => {
-//     const tp = path.join(__dirname, "RestoreCacheCacheHit.js");
-//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-//     tr.run();
-
-//     assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
-//     assert(
-//       tr.ran(
-//         `/users/tmp/ArtifactTool.exe universal download --feed node-package-feed --service https://example.visualstudio.com/defaultcollection --package-name builddefinition1 --package-version 1.0.0-${process.platform}-${Constants.Hash} --path /users/home/directory/tmp_cache --patvar UNIVERSAL_DOWNLOAD_PAT --verbosity verbose`
-//       ),
-//       "it should have run ArtifactTool"
-//     );
-//     assert(
-//       tr.stdOutContained("ArtifactTool.exe output"),
-//       "should have ArtifactTool output"
-//     );
-//     assert(tr.succeeded, "should have succeeded");
-//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
-//     assert(
-//       tr.stdOutContained("set CacheRestored=true"),
-//       "'CacheRestored' variable should be set to true"
-//     );
-//     assert(
-//       tr.stdOutContained(`${process.platform}-${Constants.Hash}=true`),
-//       "variable should be set to mark key as valid in build"
-//     );
-
-//     done();
-//   });
-
-//   it("RestoreCache runs successfully if cache hit for plat-independant cache", (done: MochaDone) => {
-//     const tp = path.join(__dirname, "RestoreCacheCacheHitPlatIndependent.js");
-//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-//     tr.run();
-
-//     assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
-//     assert(
-//       tr.ran(
-//         `/users/tmp/ArtifactTool.exe universal download --feed node-package-feed --service https://example.visualstudio.com/defaultcollection --package-name builddefinition1 --package-version 1.0.0-${Constants.Hash} --path /users/home/directory/tmp_cache --patvar UNIVERSAL_DOWNLOAD_PAT --verbosity verbose`
-//       ),
-//       "it should have run ArtifactTool for plat-independent hash"
-//     );
-//     assert(
-//       tr.stdOutContained("ArtifactTool.exe output"),
-//       "should have ArtifactTool output"
-//     );
-//     assert(tr.succeeded, "should have succeeded");
-//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
-//     assert(
-//       tr.stdOutContained("set CacheRestored=true"),
-//       "'CacheRestored' variable should be set to true"
-//     );
-//     assert(
-//       tr.stdOutContained(`${Constants.Hash}=true`),
-//       "variable should be set to mark key as valid (and plat-independent) in build"
-//     );
-
-//     done();
-//   });
-
-//   it("RestoreCache runs successfully if cache hit for cache alias", (done: MochaDone) => {
-//     const tp = path.join(__dirname, "RestoreCacheCacheHitCacheAlias.js");
-//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-//     tr.run();
-
-//     assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
-//     assert(
-//       tr.ran(
-//         `/users/tmp/ArtifactTool.exe universal download --feed node-package-feed --service https://example.visualstudio.com/defaultcollection --package-name builddefinition1 --package-version 1.0.0-${process.platform}-${Constants.Hash} --path /users/home/directory/tmp_cache --patvar UNIVERSAL_DOWNLOAD_PAT --verbosity verbose`
-//       ),
-//       "it should have run ArtifactTool"
-//     );
-//     assert(
-//       tr.stdOutContained("ArtifactTool.exe output"),
-//       "should have ArtifactTool output"
-//     );
-//     assert(tr.succeeded, "should have succeeded");
-//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
-//     assert(
-//       tr.stdOutContained("set CacheRestored-Build=true"),
-//       "'CacheRestored-Build' variable should be set to true"
-//     );
-//     assert(
-//       tr.stdOutContained(`${process.platform}-${Constants.Hash}=true`),
-//       "variable should be set to mark key as valid in build"
-//     );
-
-//     done();
-//   });
-
-//   it("RestoreCache runs successfully if cache miss", (done: MochaDone) => {
-//     const tp = path.join(__dirname, "RestoreCacheCacheMiss.js");
-//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-//     tr.run();
-
-//     assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
-//     assert(
-//       tr.ran(
-//         `/users/tmp/ArtifactTool.exe universal download --feed node-package-feed --service https://example.visualstudio.com/defaultcollection --package-name builddefinition1 --package-version 1.0.0-${process.platform}-${Constants.Hash} --path /users/home/directory/tmp_cache --patvar UNIVERSAL_DOWNLOAD_PAT --verbosity verbose`
-//       ),
-//       "it should have run ArtifactTool"
-//     );
-//     assert(
-//       tr.stdOutContained("ArtifactTool.exe output"),
-//       "should have ArtifactTool output"
-//     );
-//     assert(
-//       tr.stdOutContained(`Cache miss:  ${process.platform}-${Constants.Hash}`),
-//       "should have output stating cache miss"
-//     );
-//     assert(tr.succeeded, "should have succeeded");
-//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
-//     assert(
-//       tr.stdOutContained("set CacheRestored=false"),
-//       "'CacheRestored' variable should be set to false"
-//     );
-//     assert(
-//       tr.stdOutContained(`${process.platform}-${Constants.Hash}=false`),
-//       "variable should be set to mark key as valid in build"
-//     );
-
-//     done();
-//   });
-
-//   it("RestoreCache runs successfully if cache miss for cache alias", (done: MochaDone) => {
-//     const tp = path.join(__dirname, "RestoreCacheCacheMissCacheAlias.js");
-//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-//     tr.run();
-
-//     assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
-//     assert(
-//       tr.ran(
-//         `/users/tmp/ArtifactTool.exe universal download --feed node-package-feed --service https://example.visualstudio.com/defaultcollection --package-name builddefinition1 --package-version 1.0.0-${process.platform}-${Constants.Hash} --path /users/home/directory/tmp_cache --patvar UNIVERSAL_DOWNLOAD_PAT --verbosity verbose`
-//       ),
-//       "it should have run ArtifactTool"
-//     );
-//     assert(
-//       tr.stdOutContained("ArtifactTool.exe output"),
-//       "should have ArtifactTool output"
-//     );
-//     assert(
-//       tr.stdOutContained(`Cache miss:  ${process.platform}-${Constants.Hash}`),
-//       "should have output stating cache miss"
-//     );
-//     assert(tr.succeeded, "should have succeeded");
-//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
-//     assert(
-//       tr.stdOutContained("set CacheRestored-Build=false"),
-//       "'CacheRestored' variable should be set to false"
-//     );
-//     assert(
-//       tr.stdOutContained(`${process.platform}-${Constants.Hash}=false`),
-//       "variable should be set to mark key as valid in build"
-//     );
-
-//     done();
-//   });
-
-//   it("RestoreCache runs successfully if cache miss for dot syntax keyfile", (done: MochaDone) => {
-//     const tp = path.join(__dirname, "RestoreCacheCacheMissDotKeyFile.js");
-//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-//     tr.run();
-
-//     assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
-
-//     assert(
-//       tr.stdOutContained("Found key file: .commit"),
-//       "should have found keyfile"
-//     );
-
-//     assert(
-//       tr.stdOutContained("ArtifactTool.exe output"),
-//       "should have ArtifactTool output"
-//     );
-//     assert(
-//       tr.stdOutContained(`Cache miss:`),
-//       "should have output stating cache miss"
-//     );
-//     assert(tr.succeeded, "should have succeeded");
-//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
-//     assert(
-//       tr.stdOutContained("set CacheRestored=false"),
-//       "'CacheRestored' variable should be set to false"
-//     );
-
-//     done();
-//   });
-
-//   it("RestoreCache handles artifact permissions errors gracefully", (done: MochaDone) => {
-//     const tp = path.join(__dirname, "RestoreCachePermissionsError.js");
-//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-//     tr.run();
-
-//     assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
-//     assert(
-//       tr.ran(
-//         `/users/tmp/ArtifactTool.exe universal download --feed node-package-feed --service https://example.visualstudio.com/defaultcollection --package-name builddefinition1 --package-version 1.0.0-${process.platform}-${Constants.Hash} --path /users/home/directory/tmp_cache --patvar UNIVERSAL_DOWNLOAD_PAT --verbosity verbose`
-//       ),
-//       "it should have run ArtifactTool"
-//     );
-//     assert(
-//       tr.stdOutContained("ArtifactTool.exe output"),
-//       "should have ArtifactTool output"
-//     );
-//     assert(
-//       tr.stdOutContained(
-//         `Cache miss:  ${process.platform}-${Constants.Hash}`
-//       ) !== true,
-//       "should not have output stating cache miss"
-//     );
-//     assert(tr.succeeded, "should have succeeded");
-//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
-//     assert(tr.warningIssues.length > 0, "should have permissions warnings");
-//     assert(
-//       tr.stdOutContained(
-//         "warning;]Error: An unexpected error occurred while trying to download the package. Exit code(1) and error(An error occurred on the service. User lacks permission to complete this action.)"
-//       ),
-//       "There should be a warning about permissions"
-//     );
-//     assert(
-//       tr.stdOutContained("warning;]Issue running universal packages tools"),
-//       "There should be a warning about universal packages tools"
-//     );
-//     assert(
-//       tr.stdOutContained("set CacheRestored=false") !== true,
-//       "'CacheRestored' variable should not be set"
-//     );
-//     assert(
-//       tr.stdOutContained(`${process.platform}-${Constants.Hash}=`) !== true,
-//       "variable should not be set to mark key as valid in build"
-//     );
-
-//     done();
-//   });
-
-//   it("RestoreCache handles artifact tool download issues gracefully", (done: MochaDone) => {
-//     const tp = path.join(__dirname, "RestoreCacheArtifactToolErr.js");
-//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-//     tr.run();
-
-//     assert(
-//       tr.stdOutContained("Error initializing artifact tool"),
-//       "should have error initializing artifact tool"
-//     );
-//     assert(tr.succeeded, "should have succeeded");
-//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
-//     assert(tr.warningIssues.length > 0, "should have warnings");
-//     assert(
-//       tr.stdOutContained("set CacheRestored=") !== true,
-//       "'CacheRestored' variable should not be set"
-//     );
-//     assert(
-//       tr.stdOutContained(`set ${process.platform}-${Constants.Hash}=`) !== true,
-//       "variable should not be set to mark key as valid in build"
-//     );
-
-//     done();
-//   });
-// });
-
-// describe("SaveCache tests", function() {
-//   before(function() {
-//     process.env["SYSTEM_PULLREQUEST_ISFORK"] = "false";
-//   });
-
-//   after(() => {});
-
-//   it("SaveCache runs successfully with warnings if no key files are found", function(done: MochaDone) {
-//     const tp = path.join(__dirname, "SaveCacheNoKeyFiles.js");
-//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-//     tr.run();
-
-//     assert.equal(tr.succeeded, true, "should have succeeded");
-//     assert.equal(
-//       tr.warningIssues.length > 0,
-//       true,
-//       "should have warnings from key file"
-//     );
-//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
-//     assert.equal(
-//       tr.stdout.indexOf("no key files matching:") >= 0,
-//       true,
-//       "should display 'no key files matching:'"
-//     );
-
-//     done();
-//   });
-
-//   it("SaveCache runs successfully with warnings if no target folders are found", function(done: MochaDone) {
-//     const tp = path.join(__dirname, "SaveCacheNoTargetFolders.js");
-//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-//     tr.run();
-
-//     assert.equal(tr.succeeded, true, "should have succeeded");
-//     assert.equal(
-//       tr.warningIssues.length > 0,
-//       true,
-//       "should have warnings from target folder"
-//     );
-//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
-//     assert.equal(
-//       tr.stdout.indexOf("no target folders matching:") >= 0,
-//       true,
-//       "should display 'no target folders matching:'"
-//     );
-
-//     done();
-//   });
-
-//   it("SaveCache is skipped if no run from repository fork", function(done: MochaDone) {
-//     const tp = path.join(__dirname, "SaveCacheFromFork.js");
-//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-//     tr.run();
-
-//     assert.equal(tr.succeeded, true, "should have succeeded");
-//     assert.equal(tr.warningIssues.length, 0, "should have no warnings");
-//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
-//     assert.equal(
-//       tr.stdout.indexOf("result=Skipped;") >= 0,
-//       true,
-//       "task result should be: 'Skipped'"
-//     );
-//     assert.equal(
-//       tr.stdout.indexOf("Caches are not saved from forked repositories.") >= 0,
-//       true,
-//       "should display 'Caches are not saved from forked repositories.'"
-//     );
-
-//     done();
-//   });
-
-//   it("SaveCache doesn't create archive if cache hit", (done: MochaDone) => {
-//     const tp = path.join(__dirname, "SaveCacheCacheHit.js");
-//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-//     tr.run();
-
-//     assert(
-//       tr.stdOutContained("Cache entry already exists for:"),
-//       "should have bailed out due to cache already present"
-//     );
-//     assert(tr.succeeded, "should have succeeded");
-//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
-
-//     done();
-//   });
-
-//   it("SaveCache doesn't create an archive if no matching hash", (done: MochaDone) => {
-//     const tp = path.join(__dirname, "SaveCacheNoHashMatch.js");
-//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-//     tr.run();
-
-//     assert(
-//       tr.stdOutContained("Not caching artifact produced during build:"),
-//       "should have bailed out due to no matching hash"
-//     );
-//     assert(
-//       tr.stdOutContained("result=Skipped;"),
-//       "task result should be: 'Skipped'"
-//     );
-//     assert(tr.succeeded, "should have succeeded");
-//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
-
-//     done();
-//   });
-
-//   it("SaveCache handles artifact tool download issues gracefully", (done: MochaDone) => {
-//     const tp = path.join(__dirname, "SaveCacheArtifactToolErr.js");
-//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-//     tr.run();
-
-//     assert(
-//       tr.stdOutContained("Error initializing artifact tool"),
-//       "should have error initializing artifact tool"
-//     );
-//     assert(tr.succeeded, "should have succeeded");
-//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
-//     assert(tr.warningIssues.length > 0, "should have warnings");
-//     assert(
-//       tr.stdOutContained("set CacheRestored=") !== true,
-//       "'CacheRestored' variable should not be set"
-//     );
-//     assert(
-//       tr.stdOutContained(`set ${process.platform}-${Constants.Hash}=`) !== true,
-//       "variable should not be set to mark key as valid in build"
-//     );
-//     assert(
-//       tr.stdOutContained("Cache successfully saved") !== true,
-//       "should not have saved new cache entry"
-//     );
-
-//     done();
-//   });
-
-//   it("SaveCache handles artifact permissions errors gracefully", (done: MochaDone) => {
-//     const tp = path.join(__dirname, "SaveCachePermissionsError.js");
-//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-//     tr.run();
-
-//     assert(tr.succeeded, "should have succeeded");
-//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
-//     assert(tr.warningIssues.length > 0, "should have warnings");
-//     assert(
-//       tr.stdOutContained(
-//         "warning;]Issue saving package: Error: An unexpected error occurred while trying to push the package. Exit code(1) and error(An error occurred on the service. User lacks permission to complete this action.)"
-//       ),
-//       "There should be a warning about permissions"
-//     );
-//     assert(
-//       tr.stdOutContained(
-//         "warning;]Cache unsuccessfully saved. Find more information in logs above"
-//       ),
-//       "There should be a warning about cache not being saved"
-//     );
-//     assert(
-//       tr.stdOutContained("Cache successfully saved") !== true,
-//       "should not have saved new cache entry"
-//     );
-
-//     done();
-//   });
-
-//   it("SaveCache creates an archive if cache miss", (done: MochaDone) => {
-//     const tp = path.join(__dirname, "SaveCacheCacheMiss.js");
-//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-//     tr.run();
-
-//     assert(
-//       tr.stdOutContained("Cache successfully saved"),
-//       "should have saved new cache entry"
-//     );
-//     assert(tr.succeeded, "should have succeeded");
-//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
-
-//     done();
-//   });
-
-//   it("SaveCache creates an archive if cache miss for dot syntax keyfile", (done: MochaDone) => {
-//     const tp = path.join(__dirname, "SaveCacheCacheMissDotKeyFile.js");
-//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-//     tr.run();
-
-//     assert(
-//       tr.stdOutContained("Found key file: .commit"),
-//       "should have found keyfile '.commit'"
-//     );
-
-//     assert(
-//       tr.stdOutContained("Cache successfully saved"),
-//       "should have saved new cache entry"
-//     );
-//     assert(tr.succeeded, "should have succeeded");
-//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
-
-//     done();
-//   });
-
-//   it("SaveCache creates an archive if cache miss for dot target syntax folder patterns", (done: MochaDone) => {
-//     const tp = path.join(__dirname, "SaveCacheCacheMissDotTarget.js");
-//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-//     tr.run();
-
-//     assert(
-//       tr.stdOutContained("Found target folder: ../.build"),
-//       "should match .build target folders"
-//     );
-
-//     assert(
-//       (tr.stdout.match(/Found target folder: /g) || []).length === 1,
-//       "should find 1 target folders to cache"
-//     );
-
-//     assert(
-//       tr.stdOutContained("Cache successfully saved"),
-//       "should have saved new cache entry"
-//     );
-//     assert(tr.succeeded, "should have succeeded");
-//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
-
-//     done();
-//   });
-// });
-
-describe("DryRun tests", function() {
+describe("RestoreCache tests", function() {
   before(function() {
     process.env["SYSTEM_PULLREQUEST_ISFORK"] = "false";
   });
 
   after(() => {});
 
-  it("RestoreCache sets correct output if cache exists", (done: MochaDone) => {
-    const tp = path.join(__dirname, "RestoreCacheDryRunCacheExists.js");
+  it("RestoreCache runs successfully with warnings if no key files are found", function(done: MochaDone) {
+    const tp = path.join(__dirname, "RestoreCacheNoKeyFiles.js");
     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
     tr.run();
 
-    console.log(tr.stdout);
+    assert.equal(tr.succeeded, true, "should have succeeded");
+    assert.equal(
+      tr.warningIssues.length > 0,
+      true,
+      "should have warnings from key file"
+    );
+    assert.equal(tr.errorIssues.length, 0, "should have no errors");
+    assert.equal(
+      tr.stdout.indexOf("no key files matching:") >= 0,
+      true,
+      "should display 'no key files matching:'"
+    );
+
+    done();
+  });
+
+  it("RestoreCache is skipped if run from repository fork", function(done: MochaDone) {
+    const tp = path.join(__dirname, "RestoreCacheFromFork.js");
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+    tr.run();
+
+    assert.equal(tr.succeeded, true, "should have succeeded");
+    assert.equal(tr.warningIssues.length, 0, "should have no warnings");
+    assert.equal(tr.errorIssues.length, 0, "should have no errors");
+    assert.equal(
+      tr.stdout.indexOf("result=Skipped;") >= 0,
+      true,
+      "task result should be: 'Skipped'"
+    );
+    assert.equal(
+      tr.stdout.indexOf("Caches are not restored for forked repositories.") >=
+        0,
+      true,
+      "should display 'Caches are not restored for forked repositories.'"
+    );
+
+    done();
+  });
+
+  it("RestoreCache runs successfully if cache hit", (done: MochaDone) => {
+    const tp = path.join(__dirname, "RestoreCacheCacheHit.js");
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+    tr.run();
+
+    assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
+    assert(
+      tr.ran(
+        `/users/tmp/ArtifactTool.exe universal download --feed node-package-feed --service https://example.visualstudio.com/defaultcollection --package-name builddefinition1 --package-version 1.0.0-${process.platform}-${Constants.Hash} --path /users/home/directory/tmp_cache --patvar UNIVERSAL_DOWNLOAD_PAT --verbosity verbose`
+      ),
+      "it should have run ArtifactTool"
+    );
+    assert(
+      tr.stdOutContained("ArtifactTool.exe output"),
+      "should have ArtifactTool output"
+    );
+    assert(tr.succeeded, "should have succeeded");
+    assert.equal(tr.errorIssues.length, 0, "should have no errors");
+    assert(
+      tr.stdOutContained("set CacheRestored=true"),
+      "'CacheRestored' variable should be set to true"
+    );
+    assert(
+      tr.stdOutContained(`${process.platform}-${Constants.Hash}=true`),
+      "variable should be set to mark key as valid in build"
+    );
+
+    done();
+  });
+
+  it("RestoreCache runs successfully if cache hit for plat-independant cache", (done: MochaDone) => {
+    const tp = path.join(__dirname, "RestoreCacheCacheHitPlatIndependent.js");
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+    tr.run();
+
+    assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
+    assert(
+      tr.ran(
+        `/users/tmp/ArtifactTool.exe universal download --feed node-package-feed --service https://example.visualstudio.com/defaultcollection --package-name builddefinition1 --package-version 1.0.0-${Constants.Hash} --path /users/home/directory/tmp_cache --patvar UNIVERSAL_DOWNLOAD_PAT --verbosity verbose`
+      ),
+      "it should have run ArtifactTool for plat-independent hash"
+    );
+    assert(
+      tr.stdOutContained("ArtifactTool.exe output"),
+      "should have ArtifactTool output"
+    );
+    assert(tr.succeeded, "should have succeeded");
+    assert.equal(tr.errorIssues.length, 0, "should have no errors");
+    assert(
+      tr.stdOutContained("set CacheRestored=true"),
+      "'CacheRestored' variable should be set to true"
+    );
+    assert(
+      tr.stdOutContained(`${Constants.Hash}=true`),
+      "variable should be set to mark key as valid (and plat-independent) in build"
+    );
+
+    done();
+  });
+
+  it("RestoreCache runs successfully if cache hit for cache alias", (done: MochaDone) => {
+    const tp = path.join(__dirname, "RestoreCacheCacheHitCacheAlias.js");
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+    tr.run();
+
+    assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
+    assert(
+      tr.ran(
+        `/users/tmp/ArtifactTool.exe universal download --feed node-package-feed --service https://example.visualstudio.com/defaultcollection --package-name builddefinition1 --package-version 1.0.0-${process.platform}-${Constants.Hash} --path /users/home/directory/tmp_cache --patvar UNIVERSAL_DOWNLOAD_PAT --verbosity verbose`
+      ),
+      "it should have run ArtifactTool"
+    );
+    assert(
+      tr.stdOutContained("ArtifactTool.exe output"),
+      "should have ArtifactTool output"
+    );
+    assert(tr.succeeded, "should have succeeded");
+    assert.equal(tr.errorIssues.length, 0, "should have no errors");
+    assert(
+      tr.stdOutContained("set CacheRestored-Build=true"),
+      "'CacheRestored-Build' variable should be set to true"
+    );
+    assert(
+      tr.stdOutContained(`${process.platform}-${Constants.Hash}=true`),
+      "variable should be set to mark key as valid in build"
+    );
+
+    done();
+  });
+
+  it("RestoreCache runs successfully if cache miss", (done: MochaDone) => {
+    const tp = path.join(__dirname, "RestoreCacheCacheMiss.js");
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+    tr.run();
+
+    assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
+    assert(
+      tr.ran(
+        `/users/tmp/ArtifactTool.exe universal download --feed node-package-feed --service https://example.visualstudio.com/defaultcollection --package-name builddefinition1 --package-version 1.0.0-${process.platform}-${Constants.Hash} --path /users/home/directory/tmp_cache --patvar UNIVERSAL_DOWNLOAD_PAT --verbosity verbose`
+      ),
+      "it should have run ArtifactTool"
+    );
+    assert(
+      tr.stdOutContained("ArtifactTool.exe output"),
+      "should have ArtifactTool output"
+    );
+    assert(
+      tr.stdOutContained(`Cache miss:  ${process.platform}-${Constants.Hash}`),
+      "should have output stating cache miss"
+    );
+    assert(tr.succeeded, "should have succeeded");
+    assert.equal(tr.errorIssues.length, 0, "should have no errors");
+    assert(
+      tr.stdOutContained("set CacheRestored=false"),
+      "'CacheRestored' variable should be set to false"
+    );
+    assert(
+      tr.stdOutContained(`${process.platform}-${Constants.Hash}=false`),
+      "variable should be set to mark key as valid in build"
+    );
+
+    done();
+  });
+
+  it("RestoreCache runs successfully if cache miss for cache alias", (done: MochaDone) => {
+    const tp = path.join(__dirname, "RestoreCacheCacheMissCacheAlias.js");
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+    tr.run();
+
+    assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
+    assert(
+      tr.ran(
+        `/users/tmp/ArtifactTool.exe universal download --feed node-package-feed --service https://example.visualstudio.com/defaultcollection --package-name builddefinition1 --package-version 1.0.0-${process.platform}-${Constants.Hash} --path /users/home/directory/tmp_cache --patvar UNIVERSAL_DOWNLOAD_PAT --verbosity verbose`
+      ),
+      "it should have run ArtifactTool"
+    );
+    assert(
+      tr.stdOutContained("ArtifactTool.exe output"),
+      "should have ArtifactTool output"
+    );
+    assert(
+      tr.stdOutContained(`Cache miss:  ${process.platform}-${Constants.Hash}`),
+      "should have output stating cache miss"
+    );
+    assert(tr.succeeded, "should have succeeded");
+    assert.equal(tr.errorIssues.length, 0, "should have no errors");
+    assert(
+      tr.stdOutContained("set CacheRestored-Build=false"),
+      "'CacheRestored' variable should be set to false"
+    );
+    assert(
+      tr.stdOutContained(`${process.platform}-${Constants.Hash}=false`),
+      "variable should be set to mark key as valid in build"
+    );
+
+    done();
+  });
+
+  it("RestoreCache runs successfully if cache miss for dot syntax keyfile", (done: MochaDone) => {
+    const tp = path.join(__dirname, "RestoreCacheCacheMissDotKeyFile.js");
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+    tr.run();
+
+    assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
+
+    assert(
+      tr.stdOutContained("Found key file: .commit"),
+      "should have found keyfile"
+    );
+
+    assert(
+      tr.stdOutContained("ArtifactTool.exe output"),
+      "should have ArtifactTool output"
+    );
+    assert(
+      tr.stdOutContained(`Cache miss:`),
+      "should have output stating cache miss"
+    );
+    assert(tr.succeeded, "should have succeeded");
+    assert.equal(tr.errorIssues.length, 0, "should have no errors");
+    assert(
+      tr.stdOutContained("set CacheRestored=false"),
+      "'CacheRestored' variable should be set to false"
+    );
+
+    done();
+  });
+
+  it("RestoreCache handles artifact permissions errors gracefully", (done: MochaDone) => {
+    const tp = path.join(__dirname, "RestoreCachePermissionsError.js");
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+    tr.run();
+
+    assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
+    assert(
+      tr.ran(
+        `/users/tmp/ArtifactTool.exe universal download --feed node-package-feed --service https://example.visualstudio.com/defaultcollection --package-name builddefinition1 --package-version 1.0.0-${process.platform}-${Constants.Hash} --path /users/home/directory/tmp_cache --patvar UNIVERSAL_DOWNLOAD_PAT --verbosity verbose`
+      ),
+      "it should have run ArtifactTool"
+    );
+    assert(
+      tr.stdOutContained("ArtifactTool.exe output"),
+      "should have ArtifactTool output"
+    );
+    assert(
+      tr.stdOutContained(
+        `Cache miss:  ${process.platform}-${Constants.Hash}`
+      ) !== true,
+      "should not have output stating cache miss"
+    );
+    assert(tr.succeeded, "should have succeeded");
+    assert.equal(tr.errorIssues.length, 0, "should have no errors");
+    assert(tr.warningIssues.length > 0, "should have permissions warnings");
+    assert(
+      tr.stdOutContained(
+        "warning;]Error: An unexpected error occurred while trying to download the package. Exit code(1) and error(An error occurred on the service. User lacks permission to complete this action.)"
+      ),
+      "There should be a warning about permissions"
+    );
+    assert(
+      tr.stdOutContained("warning;]Issue running universal packages tools"),
+      "There should be a warning about universal packages tools"
+    );
+    assert(
+      tr.stdOutContained("set CacheRestored=false") !== true,
+      "'CacheRestored' variable should not be set"
+    );
+    assert(
+      tr.stdOutContained(`${process.platform}-${Constants.Hash}=`) !== true,
+      "variable should not be set to mark key as valid in build"
+    );
+
+    done();
+  });
+
+  it("RestoreCache handles artifact tool download issues gracefully", (done: MochaDone) => {
+    const tp = path.join(__dirname, "RestoreCacheArtifactToolErr.js");
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+    tr.run();
+
+    assert(
+      tr.stdOutContained("Error initializing artifact tool"),
+      "should have error initializing artifact tool"
+    );
+    assert(tr.succeeded, "should have succeeded");
+    assert.equal(tr.errorIssues.length, 0, "should have no errors");
+    assert(tr.warningIssues.length > 0, "should have warnings");
+    assert(
+      tr.stdOutContained("set CacheRestored=") !== true,
+      "'CacheRestored' variable should not be set"
+    );
+    assert(
+      tr.stdOutContained(`set ${process.platform}-${Constants.Hash}=`) !== true,
+      "variable should not be set to mark key as valid in build"
+    );
+
+    done();
+  });
+});
+
+describe("SaveCache tests", function() {
+  before(function() {
+    process.env["SYSTEM_PULLREQUEST_ISFORK"] = "false";
+  });
+
+  after(() => {});
+
+  it("SaveCache runs successfully with warnings if no key files are found", function(done: MochaDone) {
+    const tp = path.join(__dirname, "SaveCacheNoKeyFiles.js");
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+    tr.run();
+
+    assert.equal(tr.succeeded, true, "should have succeeded");
+    assert.equal(
+      tr.warningIssues.length > 0,
+      true,
+      "should have warnings from key file"
+    );
+    assert.equal(tr.errorIssues.length, 0, "should have no errors");
+    assert.equal(
+      tr.stdout.indexOf("no key files matching:") >= 0,
+      true,
+      "should display 'no key files matching:'"
+    );
+
+    done();
+  });
+
+  it("SaveCache runs successfully with warnings if no target folders are found", function(done: MochaDone) {
+    const tp = path.join(__dirname, "SaveCacheNoTargetFolders.js");
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+    tr.run();
+
+    assert.equal(tr.succeeded, true, "should have succeeded");
+    assert.equal(
+      tr.warningIssues.length > 0,
+      true,
+      "should have warnings from target folder"
+    );
+    assert.equal(tr.errorIssues.length, 0, "should have no errors");
+    assert.equal(
+      tr.stdout.indexOf("no target folders matching:") >= 0,
+      true,
+      "should display 'no target folders matching:'"
+    );
+
+    done();
+  });
+
+  it("SaveCache is skipped if no run from repository fork", function(done: MochaDone) {
+    const tp = path.join(__dirname, "SaveCacheFromFork.js");
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+    tr.run();
+
+    assert.equal(tr.succeeded, true, "should have succeeded");
+    assert.equal(tr.warningIssues.length, 0, "should have no warnings");
+    assert.equal(tr.errorIssues.length, 0, "should have no errors");
+    assert.equal(
+      tr.stdout.indexOf("result=Skipped;") >= 0,
+      true,
+      "task result should be: 'Skipped'"
+    );
+    assert.equal(
+      tr.stdout.indexOf("Caches are not saved from forked repositories.") >= 0,
+      true,
+      "should display 'Caches are not saved from forked repositories.'"
+    );
+
+    done();
+  });
+
+  it("SaveCache doesn't create archive if cache hit", (done: MochaDone) => {
+    const tp = path.join(__dirname, "SaveCacheCacheHit.js");
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+    tr.run();
+
+    assert(
+      tr.stdOutContained("Cache entry already exists for:"),
+      "should have bailed out due to cache already present"
+    );
+    assert(tr.succeeded, "should have succeeded");
+    assert.equal(tr.errorIssues.length, 0, "should have no errors");
+
+    done();
+  });
+
+  it("SaveCache doesn't create an archive if no matching hash", (done: MochaDone) => {
+    const tp = path.join(__dirname, "SaveCacheNoHashMatch.js");
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+    tr.run();
+
+    assert(
+      tr.stdOutContained("Not caching artifact produced during build:"),
+      "should have bailed out due to no matching hash"
+    );
+    assert(
+      tr.stdOutContained("result=Skipped;"),
+      "task result should be: 'Skipped'"
+    );
+    assert(tr.succeeded, "should have succeeded");
+    assert.equal(tr.errorIssues.length, 0, "should have no errors");
+
+    done();
+  });
+
+  it("SaveCache handles artifact tool download issues gracefully", (done: MochaDone) => {
+    const tp = path.join(__dirname, "SaveCacheArtifactToolErr.js");
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+    tr.run();
+
+    assert(
+      tr.stdOutContained("Error initializing artifact tool"),
+      "should have error initializing artifact tool"
+    );
+    assert(tr.succeeded, "should have succeeded");
+    assert.equal(tr.errorIssues.length, 0, "should have no errors");
+    assert(tr.warningIssues.length > 0, "should have warnings");
+    assert(
+      tr.stdOutContained("set CacheRestored=") !== true,
+      "'CacheRestored' variable should not be set"
+    );
+    assert(
+      tr.stdOutContained(`set ${process.platform}-${Constants.Hash}=`) !== true,
+      "variable should not be set to mark key as valid in build"
+    );
+    assert(
+      tr.stdOutContained("Cache successfully saved") !== true,
+      "should not have saved new cache entry"
+    );
+
+    done();
+  });
+
+  it("SaveCache handles artifact permissions errors gracefully", (done: MochaDone) => {
+    const tp = path.join(__dirname, "SaveCachePermissionsError.js");
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+    tr.run();
+
+    assert(tr.succeeded, "should have succeeded");
+    assert.equal(tr.errorIssues.length, 0, "should have no errors");
+    assert(tr.warningIssues.length > 0, "should have warnings");
+    assert(
+      tr.stdOutContained(
+        "warning;]Issue saving package: Error: An unexpected error occurred while trying to push the package. Exit code(1) and error(An error occurred on the service. User lacks permission to complete this action.)"
+      ),
+      "There should be a warning about permissions"
+    );
+    assert(
+      tr.stdOutContained(
+        "warning;]Cache unsuccessfully saved. Find more information in logs above"
+      ),
+      "There should be a warning about cache not being saved"
+    );
+    assert(
+      tr.stdOutContained("Cache successfully saved") !== true,
+      "should not have saved new cache entry"
+    );
+
+    done();
+  });
+
+  it("SaveCache creates an archive if cache miss", (done: MochaDone) => {
+    const tp = path.join(__dirname, "SaveCacheCacheMiss.js");
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+    tr.run();
+
+    assert(
+      tr.stdOutContained("Cache successfully saved"),
+      "should have saved new cache entry"
+    );
+    assert(tr.succeeded, "should have succeeded");
+    assert.equal(tr.errorIssues.length, 0, "should have no errors");
+
+    done();
+  });
+
+  it("SaveCache creates an archive if cache miss for dot syntax keyfile", (done: MochaDone) => {
+    const tp = path.join(__dirname, "SaveCacheCacheMissDotKeyFile.js");
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+    tr.run();
+
+    assert(
+      tr.stdOutContained("Found key file: .commit"),
+      "should have found keyfile '.commit'"
+    );
+
+    assert(
+      tr.stdOutContained("Cache successfully saved"),
+      "should have saved new cache entry"
+    );
+    assert(tr.succeeded, "should have succeeded");
+    assert.equal(tr.errorIssues.length, 0, "should have no errors");
+
+    done();
+  });
+
+  it("SaveCache creates an archive if cache miss for dot target syntax folder patterns", (done: MochaDone) => {
+    const tp = path.join(__dirname, "SaveCacheCacheMissDotTarget.js");
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+    tr.run();
 
     assert(
       tr.stdOutContained("Found target folder: ../.build"),
@@ -592,6 +555,52 @@ describe("DryRun tests", function() {
     );
     assert(tr.succeeded, "should have succeeded");
     assert.equal(tr.errorIssues.length, 0, "should have no errors");
+
+    done();
+  });
+});
+
+describe("DryRun tests", function() {
+  before(function() {
+    process.env["SYSTEM_PULLREQUEST_ISFORK"] = "false";
+  });
+
+  after(() => {});
+
+  it("RestoreCache sets correct output if cache exists", (done: MochaDone) => {
+    const tp = path.join(__dirname, "RestoreCacheDryRunCacheExists.js");
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+    tr.run();
+
+    assert(
+      tr.stdOutContained("set CacheExists=true"),
+      "should state that cache exists"
+    );
+
+    assert(
+      tr.stdOutContained(`${process.platform}-${Constants.Hash}=true`),
+      "variable should be set to mark key as valid in build"
+    );
+
+    done();
+  });
+
+  it("RestoreCache sets correct output if cache does not exists", (done: MochaDone) => {
+    const tp = path.join(__dirname, "RestoreCacheDryRunCacheNotExists.js");
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+    tr.run();
+
+    assert(
+      tr.stdOutContained("set CacheExists=false"),
+      "should state that cache exists"
+    );
+
+    assert(
+      tr.stdOutContained(`${process.platform}-${Constants.Hash}=false`),
+      "variable should be set to mark key as valid in build"
+    );
 
     done();
   });

--- a/Tasks/RestoreAndSaveCacheV1/Tests/_suite.ts
+++ b/Tasks/RestoreAndSaveCacheV1/Tests/_suite.ts
@@ -8,559 +8,573 @@ before(function() {
   this.timeout(5000);
 });
 
-describe("RestoreCache tests", function() {
+// describe("RestoreCache tests", function() {
+//   before(function() {
+//     process.env["SYSTEM_PULLREQUEST_ISFORK"] = "false";
+//   });
+
+//   after(() => {});
+
+//   it("RestoreCache runs successfully with warnings if no key files are found", function(done: MochaDone) {
+//     const tp = path.join(__dirname, "RestoreCacheNoKeyFiles.js");
+//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+//     tr.run();
+
+//     assert.equal(tr.succeeded, true, "should have succeeded");
+//     assert.equal(
+//       tr.warningIssues.length > 0,
+//       true,
+//       "should have warnings from key file"
+//     );
+//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
+//     assert.equal(
+//       tr.stdout.indexOf("no key files matching:") >= 0,
+//       true,
+//       "should display 'no key files matching:'"
+//     );
+
+//     done();
+//   });
+
+//   it("RestoreCache is skipped if run from repository fork", function(done: MochaDone) {
+//     const tp = path.join(__dirname, "RestoreCacheFromFork.js");
+//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+//     tr.run();
+
+//     assert.equal(tr.succeeded, true, "should have succeeded");
+//     assert.equal(tr.warningIssues.length, 0, "should have no warnings");
+//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
+//     assert.equal(
+//       tr.stdout.indexOf("result=Skipped;") >= 0,
+//       true,
+//       "task result should be: 'Skipped'"
+//     );
+//     assert.equal(
+//       tr.stdout.indexOf("Caches are not restored for forked repositories.") >=
+//         0,
+//       true,
+//       "should display 'Caches are not restored for forked repositories.'"
+//     );
+
+//     done();
+//   });
+
+//   it("RestoreCache runs successfully if cache hit", (done: MochaDone) => {
+//     const tp = path.join(__dirname, "RestoreCacheCacheHit.js");
+//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+//     tr.run();
+
+//     assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
+//     assert(
+//       tr.ran(
+//         `/users/tmp/ArtifactTool.exe universal download --feed node-package-feed --service https://example.visualstudio.com/defaultcollection --package-name builddefinition1 --package-version 1.0.0-${process.platform}-${Constants.Hash} --path /users/home/directory/tmp_cache --patvar UNIVERSAL_DOWNLOAD_PAT --verbosity verbose`
+//       ),
+//       "it should have run ArtifactTool"
+//     );
+//     assert(
+//       tr.stdOutContained("ArtifactTool.exe output"),
+//       "should have ArtifactTool output"
+//     );
+//     assert(tr.succeeded, "should have succeeded");
+//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
+//     assert(
+//       tr.stdOutContained("set CacheRestored=true"),
+//       "'CacheRestored' variable should be set to true"
+//     );
+//     assert(
+//       tr.stdOutContained(`${process.platform}-${Constants.Hash}=true`),
+//       "variable should be set to mark key as valid in build"
+//     );
+
+//     done();
+//   });
+
+//   it("RestoreCache runs successfully if cache hit for plat-independant cache", (done: MochaDone) => {
+//     const tp = path.join(__dirname, "RestoreCacheCacheHitPlatIndependent.js");
+//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+//     tr.run();
+
+//     assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
+//     assert(
+//       tr.ran(
+//         `/users/tmp/ArtifactTool.exe universal download --feed node-package-feed --service https://example.visualstudio.com/defaultcollection --package-name builddefinition1 --package-version 1.0.0-${Constants.Hash} --path /users/home/directory/tmp_cache --patvar UNIVERSAL_DOWNLOAD_PAT --verbosity verbose`
+//       ),
+//       "it should have run ArtifactTool for plat-independent hash"
+//     );
+//     assert(
+//       tr.stdOutContained("ArtifactTool.exe output"),
+//       "should have ArtifactTool output"
+//     );
+//     assert(tr.succeeded, "should have succeeded");
+//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
+//     assert(
+//       tr.stdOutContained("set CacheRestored=true"),
+//       "'CacheRestored' variable should be set to true"
+//     );
+//     assert(
+//       tr.stdOutContained(`${Constants.Hash}=true`),
+//       "variable should be set to mark key as valid (and plat-independent) in build"
+//     );
+
+//     done();
+//   });
+
+//   it("RestoreCache runs successfully if cache hit for cache alias", (done: MochaDone) => {
+//     const tp = path.join(__dirname, "RestoreCacheCacheHitCacheAlias.js");
+//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+//     tr.run();
+
+//     assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
+//     assert(
+//       tr.ran(
+//         `/users/tmp/ArtifactTool.exe universal download --feed node-package-feed --service https://example.visualstudio.com/defaultcollection --package-name builddefinition1 --package-version 1.0.0-${process.platform}-${Constants.Hash} --path /users/home/directory/tmp_cache --patvar UNIVERSAL_DOWNLOAD_PAT --verbosity verbose`
+//       ),
+//       "it should have run ArtifactTool"
+//     );
+//     assert(
+//       tr.stdOutContained("ArtifactTool.exe output"),
+//       "should have ArtifactTool output"
+//     );
+//     assert(tr.succeeded, "should have succeeded");
+//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
+//     assert(
+//       tr.stdOutContained("set CacheRestored-Build=true"),
+//       "'CacheRestored-Build' variable should be set to true"
+//     );
+//     assert(
+//       tr.stdOutContained(`${process.platform}-${Constants.Hash}=true`),
+//       "variable should be set to mark key as valid in build"
+//     );
+
+//     done();
+//   });
+
+//   it("RestoreCache runs successfully if cache miss", (done: MochaDone) => {
+//     const tp = path.join(__dirname, "RestoreCacheCacheMiss.js");
+//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+//     tr.run();
+
+//     assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
+//     assert(
+//       tr.ran(
+//         `/users/tmp/ArtifactTool.exe universal download --feed node-package-feed --service https://example.visualstudio.com/defaultcollection --package-name builddefinition1 --package-version 1.0.0-${process.platform}-${Constants.Hash} --path /users/home/directory/tmp_cache --patvar UNIVERSAL_DOWNLOAD_PAT --verbosity verbose`
+//       ),
+//       "it should have run ArtifactTool"
+//     );
+//     assert(
+//       tr.stdOutContained("ArtifactTool.exe output"),
+//       "should have ArtifactTool output"
+//     );
+//     assert(
+//       tr.stdOutContained(`Cache miss:  ${process.platform}-${Constants.Hash}`),
+//       "should have output stating cache miss"
+//     );
+//     assert(tr.succeeded, "should have succeeded");
+//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
+//     assert(
+//       tr.stdOutContained("set CacheRestored=false"),
+//       "'CacheRestored' variable should be set to false"
+//     );
+//     assert(
+//       tr.stdOutContained(`${process.platform}-${Constants.Hash}=false`),
+//       "variable should be set to mark key as valid in build"
+//     );
+
+//     done();
+//   });
+
+//   it("RestoreCache runs successfully if cache miss for cache alias", (done: MochaDone) => {
+//     const tp = path.join(__dirname, "RestoreCacheCacheMissCacheAlias.js");
+//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+//     tr.run();
+
+//     assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
+//     assert(
+//       tr.ran(
+//         `/users/tmp/ArtifactTool.exe universal download --feed node-package-feed --service https://example.visualstudio.com/defaultcollection --package-name builddefinition1 --package-version 1.0.0-${process.platform}-${Constants.Hash} --path /users/home/directory/tmp_cache --patvar UNIVERSAL_DOWNLOAD_PAT --verbosity verbose`
+//       ),
+//       "it should have run ArtifactTool"
+//     );
+//     assert(
+//       tr.stdOutContained("ArtifactTool.exe output"),
+//       "should have ArtifactTool output"
+//     );
+//     assert(
+//       tr.stdOutContained(`Cache miss:  ${process.platform}-${Constants.Hash}`),
+//       "should have output stating cache miss"
+//     );
+//     assert(tr.succeeded, "should have succeeded");
+//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
+//     assert(
+//       tr.stdOutContained("set CacheRestored-Build=false"),
+//       "'CacheRestored' variable should be set to false"
+//     );
+//     assert(
+//       tr.stdOutContained(`${process.platform}-${Constants.Hash}=false`),
+//       "variable should be set to mark key as valid in build"
+//     );
+
+//     done();
+//   });
+
+//   it("RestoreCache runs successfully if cache miss for dot syntax keyfile", (done: MochaDone) => {
+//     const tp = path.join(__dirname, "RestoreCacheCacheMissDotKeyFile.js");
+//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+//     tr.run();
+
+//     assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
+
+//     assert(
+//       tr.stdOutContained("Found key file: .commit"),
+//       "should have found keyfile"
+//     );
+
+//     assert(
+//       tr.stdOutContained("ArtifactTool.exe output"),
+//       "should have ArtifactTool output"
+//     );
+//     assert(
+//       tr.stdOutContained(`Cache miss:`),
+//       "should have output stating cache miss"
+//     );
+//     assert(tr.succeeded, "should have succeeded");
+//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
+//     assert(
+//       tr.stdOutContained("set CacheRestored=false"),
+//       "'CacheRestored' variable should be set to false"
+//     );
+
+//     done();
+//   });
+
+//   it("RestoreCache handles artifact permissions errors gracefully", (done: MochaDone) => {
+//     const tp = path.join(__dirname, "RestoreCachePermissionsError.js");
+//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+//     tr.run();
+
+//     assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
+//     assert(
+//       tr.ran(
+//         `/users/tmp/ArtifactTool.exe universal download --feed node-package-feed --service https://example.visualstudio.com/defaultcollection --package-name builddefinition1 --package-version 1.0.0-${process.platform}-${Constants.Hash} --path /users/home/directory/tmp_cache --patvar UNIVERSAL_DOWNLOAD_PAT --verbosity verbose`
+//       ),
+//       "it should have run ArtifactTool"
+//     );
+//     assert(
+//       tr.stdOutContained("ArtifactTool.exe output"),
+//       "should have ArtifactTool output"
+//     );
+//     assert(
+//       tr.stdOutContained(
+//         `Cache miss:  ${process.platform}-${Constants.Hash}`
+//       ) !== true,
+//       "should not have output stating cache miss"
+//     );
+//     assert(tr.succeeded, "should have succeeded");
+//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
+//     assert(tr.warningIssues.length > 0, "should have permissions warnings");
+//     assert(
+//       tr.stdOutContained(
+//         "warning;]Error: An unexpected error occurred while trying to download the package. Exit code(1) and error(An error occurred on the service. User lacks permission to complete this action.)"
+//       ),
+//       "There should be a warning about permissions"
+//     );
+//     assert(
+//       tr.stdOutContained("warning;]Issue running universal packages tools"),
+//       "There should be a warning about universal packages tools"
+//     );
+//     assert(
+//       tr.stdOutContained("set CacheRestored=false") !== true,
+//       "'CacheRestored' variable should not be set"
+//     );
+//     assert(
+//       tr.stdOutContained(`${process.platform}-${Constants.Hash}=`) !== true,
+//       "variable should not be set to mark key as valid in build"
+//     );
+
+//     done();
+//   });
+
+//   it("RestoreCache handles artifact tool download issues gracefully", (done: MochaDone) => {
+//     const tp = path.join(__dirname, "RestoreCacheArtifactToolErr.js");
+//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+//     tr.run();
+
+//     assert(
+//       tr.stdOutContained("Error initializing artifact tool"),
+//       "should have error initializing artifact tool"
+//     );
+//     assert(tr.succeeded, "should have succeeded");
+//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
+//     assert(tr.warningIssues.length > 0, "should have warnings");
+//     assert(
+//       tr.stdOutContained("set CacheRestored=") !== true,
+//       "'CacheRestored' variable should not be set"
+//     );
+//     assert(
+//       tr.stdOutContained(`set ${process.platform}-${Constants.Hash}=`) !== true,
+//       "variable should not be set to mark key as valid in build"
+//     );
+
+//     done();
+//   });
+// });
+
+// describe("SaveCache tests", function() {
+//   before(function() {
+//     process.env["SYSTEM_PULLREQUEST_ISFORK"] = "false";
+//   });
+
+//   after(() => {});
+
+//   it("SaveCache runs successfully with warnings if no key files are found", function(done: MochaDone) {
+//     const tp = path.join(__dirname, "SaveCacheNoKeyFiles.js");
+//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+//     tr.run();
+
+//     assert.equal(tr.succeeded, true, "should have succeeded");
+//     assert.equal(
+//       tr.warningIssues.length > 0,
+//       true,
+//       "should have warnings from key file"
+//     );
+//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
+//     assert.equal(
+//       tr.stdout.indexOf("no key files matching:") >= 0,
+//       true,
+//       "should display 'no key files matching:'"
+//     );
+
+//     done();
+//   });
+
+//   it("SaveCache runs successfully with warnings if no target folders are found", function(done: MochaDone) {
+//     const tp = path.join(__dirname, "SaveCacheNoTargetFolders.js");
+//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+//     tr.run();
+
+//     assert.equal(tr.succeeded, true, "should have succeeded");
+//     assert.equal(
+//       tr.warningIssues.length > 0,
+//       true,
+//       "should have warnings from target folder"
+//     );
+//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
+//     assert.equal(
+//       tr.stdout.indexOf("no target folders matching:") >= 0,
+//       true,
+//       "should display 'no target folders matching:'"
+//     );
+
+//     done();
+//   });
+
+//   it("SaveCache is skipped if no run from repository fork", function(done: MochaDone) {
+//     const tp = path.join(__dirname, "SaveCacheFromFork.js");
+//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+//     tr.run();
+
+//     assert.equal(tr.succeeded, true, "should have succeeded");
+//     assert.equal(tr.warningIssues.length, 0, "should have no warnings");
+//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
+//     assert.equal(
+//       tr.stdout.indexOf("result=Skipped;") >= 0,
+//       true,
+//       "task result should be: 'Skipped'"
+//     );
+//     assert.equal(
+//       tr.stdout.indexOf("Caches are not saved from forked repositories.") >= 0,
+//       true,
+//       "should display 'Caches are not saved from forked repositories.'"
+//     );
+
+//     done();
+//   });
+
+//   it("SaveCache doesn't create archive if cache hit", (done: MochaDone) => {
+//     const tp = path.join(__dirname, "SaveCacheCacheHit.js");
+//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+//     tr.run();
+
+//     assert(
+//       tr.stdOutContained("Cache entry already exists for:"),
+//       "should have bailed out due to cache already present"
+//     );
+//     assert(tr.succeeded, "should have succeeded");
+//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
+
+//     done();
+//   });
+
+//   it("SaveCache doesn't create an archive if no matching hash", (done: MochaDone) => {
+//     const tp = path.join(__dirname, "SaveCacheNoHashMatch.js");
+//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+//     tr.run();
+
+//     assert(
+//       tr.stdOutContained("Not caching artifact produced during build:"),
+//       "should have bailed out due to no matching hash"
+//     );
+//     assert(
+//       tr.stdOutContained("result=Skipped;"),
+//       "task result should be: 'Skipped'"
+//     );
+//     assert(tr.succeeded, "should have succeeded");
+//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
+
+//     done();
+//   });
+
+//   it("SaveCache handles artifact tool download issues gracefully", (done: MochaDone) => {
+//     const tp = path.join(__dirname, "SaveCacheArtifactToolErr.js");
+//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+//     tr.run();
+
+//     assert(
+//       tr.stdOutContained("Error initializing artifact tool"),
+//       "should have error initializing artifact tool"
+//     );
+//     assert(tr.succeeded, "should have succeeded");
+//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
+//     assert(tr.warningIssues.length > 0, "should have warnings");
+//     assert(
+//       tr.stdOutContained("set CacheRestored=") !== true,
+//       "'CacheRestored' variable should not be set"
+//     );
+//     assert(
+//       tr.stdOutContained(`set ${process.platform}-${Constants.Hash}=`) !== true,
+//       "variable should not be set to mark key as valid in build"
+//     );
+//     assert(
+//       tr.stdOutContained("Cache successfully saved") !== true,
+//       "should not have saved new cache entry"
+//     );
+
+//     done();
+//   });
+
+//   it("SaveCache handles artifact permissions errors gracefully", (done: MochaDone) => {
+//     const tp = path.join(__dirname, "SaveCachePermissionsError.js");
+//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+//     tr.run();
+
+//     assert(tr.succeeded, "should have succeeded");
+//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
+//     assert(tr.warningIssues.length > 0, "should have warnings");
+//     assert(
+//       tr.stdOutContained(
+//         "warning;]Issue saving package: Error: An unexpected error occurred while trying to push the package. Exit code(1) and error(An error occurred on the service. User lacks permission to complete this action.)"
+//       ),
+//       "There should be a warning about permissions"
+//     );
+//     assert(
+//       tr.stdOutContained(
+//         "warning;]Cache unsuccessfully saved. Find more information in logs above"
+//       ),
+//       "There should be a warning about cache not being saved"
+//     );
+//     assert(
+//       tr.stdOutContained("Cache successfully saved") !== true,
+//       "should not have saved new cache entry"
+//     );
+
+//     done();
+//   });
+
+//   it("SaveCache creates an archive if cache miss", (done: MochaDone) => {
+//     const tp = path.join(__dirname, "SaveCacheCacheMiss.js");
+//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+//     tr.run();
+
+//     assert(
+//       tr.stdOutContained("Cache successfully saved"),
+//       "should have saved new cache entry"
+//     );
+//     assert(tr.succeeded, "should have succeeded");
+//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
+
+//     done();
+//   });
+
+//   it("SaveCache creates an archive if cache miss for dot syntax keyfile", (done: MochaDone) => {
+//     const tp = path.join(__dirname, "SaveCacheCacheMissDotKeyFile.js");
+//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+//     tr.run();
+
+//     assert(
+//       tr.stdOutContained("Found key file: .commit"),
+//       "should have found keyfile '.commit'"
+//     );
+
+//     assert(
+//       tr.stdOutContained("Cache successfully saved"),
+//       "should have saved new cache entry"
+//     );
+//     assert(tr.succeeded, "should have succeeded");
+//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
+
+//     done();
+//   });
+
+//   it("SaveCache creates an archive if cache miss for dot target syntax folder patterns", (done: MochaDone) => {
+//     const tp = path.join(__dirname, "SaveCacheCacheMissDotTarget.js");
+//     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+//     tr.run();
+
+//     assert(
+//       tr.stdOutContained("Found target folder: ../.build"),
+//       "should match .build target folders"
+//     );
+
+//     assert(
+//       (tr.stdout.match(/Found target folder: /g) || []).length === 1,
+//       "should find 1 target folders to cache"
+//     );
+
+//     assert(
+//       tr.stdOutContained("Cache successfully saved"),
+//       "should have saved new cache entry"
+//     );
+//     assert(tr.succeeded, "should have succeeded");
+//     assert.equal(tr.errorIssues.length, 0, "should have no errors");
+
+//     done();
+//   });
+// });
+
+describe("DryRun tests", function() {
   before(function() {
     process.env["SYSTEM_PULLREQUEST_ISFORK"] = "false";
   });
 
   after(() => {});
 
-  it("RestoreCache runs successfully with warnings if no key files are found", function(done: MochaDone) {
-    const tp = path.join(__dirname, "RestoreCacheNoKeyFiles.js");
+  it("RestoreCache sets correct output if cache exists", (done: MochaDone) => {
+    const tp = path.join(__dirname, "RestoreCacheDryRunCacheExists.js");
     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
     tr.run();
 
-    assert.equal(tr.succeeded, true, "should have succeeded");
-    assert.equal(
-      tr.warningIssues.length > 0,
-      true,
-      "should have warnings from key file"
-    );
-    assert.equal(tr.errorIssues.length, 0, "should have no errors");
-    assert.equal(
-      tr.stdout.indexOf("no key files matching:") >= 0,
-      true,
-      "should display 'no key files matching:'"
-    );
-
-    done();
-  });
-
-  it("RestoreCache is skipped if run from repository fork", function(done: MochaDone) {
-    const tp = path.join(__dirname, "RestoreCacheFromFork.js");
-    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-    tr.run();
-
-    assert.equal(tr.succeeded, true, "should have succeeded");
-    assert.equal(tr.warningIssues.length, 0, "should have no warnings");
-    assert.equal(tr.errorIssues.length, 0, "should have no errors");
-    assert.equal(
-      tr.stdout.indexOf("result=Skipped;") >= 0,
-      true,
-      "task result should be: 'Skipped'"
-    );
-    assert.equal(
-      tr.stdout.indexOf("Caches are not restored for forked repositories.") >=
-        0,
-      true,
-      "should display 'Caches are not restored for forked repositories.'"
-    );
-
-    done();
-  });
-
-  it("RestoreCache runs successfully if cache hit", (done: MochaDone) => {
-    const tp = path.join(__dirname, "RestoreCacheCacheHit.js");
-    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-    tr.run();
-
-    assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
-    assert(
-      tr.ran(
-        `/users/tmp/ArtifactTool.exe universal download --feed node-package-feed --service https://example.visualstudio.com/defaultcollection --package-name builddefinition1 --package-version 1.0.0-${
-          process.platform
-        }-${
-          Constants.Hash
-        } --path /users/home/directory/tmp_cache --patvar UNIVERSAL_DOWNLOAD_PAT --verbosity verbose`
-      ),
-      "it should have run ArtifactTool"
-    );
-    assert(
-      tr.stdOutContained("ArtifactTool.exe output"),
-      "should have ArtifactTool output"
-    );
-    assert(tr.succeeded, "should have succeeded");
-    assert.equal(tr.errorIssues.length, 0, "should have no errors");
-    assert(
-      tr.stdOutContained("set CacheRestored=true"),
-      "'CacheRestored' variable should be set to true"
-    );
-    assert(
-      tr.stdOutContained(`${process.platform}-${Constants.Hash}=true`),
-      "variable should be set to mark key as valid in build"
-    );
-
-    done();
-  });
-
-  it("RestoreCache runs successfully if cache hit for plat-independant cache", (done: MochaDone) => {
-    const tp = path.join(__dirname, "RestoreCacheCacheHitPlatIndependent.js");
-    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-    tr.run();
-
-    assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
-    assert(
-      tr.ran(
-        `/users/tmp/ArtifactTool.exe universal download --feed node-package-feed --service https://example.visualstudio.com/defaultcollection --package-name builddefinition1 --package-version 1.0.0-${
-          Constants.Hash
-        } --path /users/home/directory/tmp_cache --patvar UNIVERSAL_DOWNLOAD_PAT --verbosity verbose`
-      ),
-      "it should have run ArtifactTool for plat-independent hash"
-    );
-    assert(
-      tr.stdOutContained("ArtifactTool.exe output"),
-      "should have ArtifactTool output"
-    );
-    assert(tr.succeeded, "should have succeeded");
-    assert.equal(tr.errorIssues.length, 0, "should have no errors");
-    assert(
-      tr.stdOutContained("set CacheRestored=true"),
-      "'CacheRestored' variable should be set to true"
-    );
-    assert(
-      tr.stdOutContained(`${Constants.Hash}=true`),
-      "variable should be set to mark key as valid (and plat-independent) in build"
-    );
-
-    done();
-  });
-
-  it("RestoreCache runs successfully if cache hit for cache alias", (done: MochaDone) => {
-    const tp = path.join(__dirname, "RestoreCacheCacheHitCacheAlias.js");
-    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-    tr.run();
-
-    assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
-    assert(
-      tr.ran(
-        `/users/tmp/ArtifactTool.exe universal download --feed node-package-feed --service https://example.visualstudio.com/defaultcollection --package-name builddefinition1 --package-version 1.0.0-${
-          process.platform
-        }-${
-          Constants.Hash
-        } --path /users/home/directory/tmp_cache --patvar UNIVERSAL_DOWNLOAD_PAT --verbosity verbose`
-      ),
-      "it should have run ArtifactTool"
-    );
-    assert(
-      tr.stdOutContained("ArtifactTool.exe output"),
-      "should have ArtifactTool output"
-    );
-    assert(tr.succeeded, "should have succeeded");
-    assert.equal(tr.errorIssues.length, 0, "should have no errors");
-    assert(
-      tr.stdOutContained("set CacheRestored-Build=true"),
-      "'CacheRestored-Build' variable should be set to true"
-    );
-    assert(
-      tr.stdOutContained(`${process.platform}-${Constants.Hash}=true`),
-      "variable should be set to mark key as valid in build"
-    );
-
-    done();
-  });
-
-  it("RestoreCache runs successfully if cache miss", (done: MochaDone) => {
-    const tp = path.join(__dirname, "RestoreCacheCacheMiss.js");
-    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-    tr.run();
-
-    assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
-    assert(
-      tr.ran(
-        `/users/tmp/ArtifactTool.exe universal download --feed node-package-feed --service https://example.visualstudio.com/defaultcollection --package-name builddefinition1 --package-version 1.0.0-${
-          process.platform
-        }-${
-          Constants.Hash
-        } --path /users/home/directory/tmp_cache --patvar UNIVERSAL_DOWNLOAD_PAT --verbosity verbose`
-      ),
-      "it should have run ArtifactTool"
-    );
-    assert(
-      tr.stdOutContained("ArtifactTool.exe output"),
-      "should have ArtifactTool output"
-    );
-    assert(
-      tr.stdOutContained(`Cache miss:  ${process.platform}-${Constants.Hash}`),
-      "should have output stating cache miss"
-    );
-    assert(tr.succeeded, "should have succeeded");
-    assert.equal(tr.errorIssues.length, 0, "should have no errors");
-    assert(
-      tr.stdOutContained("set CacheRestored=false"),
-      "'CacheRestored' variable should be set to false"
-    );
-    assert(
-      tr.stdOutContained(`${process.platform}-${Constants.Hash}=false`),
-      "variable should be set to mark key as valid in build"
-    );
-
-    done();
-  });
-
-  it("RestoreCache runs successfully if cache miss for cache alias", (done: MochaDone) => {
-    const tp = path.join(__dirname, "RestoreCacheCacheMissCacheAlias.js");
-    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-    tr.run();
-
-    assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
-    assert(
-      tr.ran(
-        `/users/tmp/ArtifactTool.exe universal download --feed node-package-feed --service https://example.visualstudio.com/defaultcollection --package-name builddefinition1 --package-version 1.0.0-${
-          process.platform
-        }-${
-          Constants.Hash
-        } --path /users/home/directory/tmp_cache --patvar UNIVERSAL_DOWNLOAD_PAT --verbosity verbose`
-      ),
-      "it should have run ArtifactTool"
-    );
-    assert(
-      tr.stdOutContained("ArtifactTool.exe output"),
-      "should have ArtifactTool output"
-    );
-    assert(
-      tr.stdOutContained(`Cache miss:  ${process.platform}-${Constants.Hash}`),
-      "should have output stating cache miss"
-    );
-    assert(tr.succeeded, "should have succeeded");
-    assert.equal(tr.errorIssues.length, 0, "should have no errors");
-    assert(
-      tr.stdOutContained("set CacheRestored-Build=false"),
-      "'CacheRestored' variable should be set to false"
-    );
-    assert(
-      tr.stdOutContained(`${process.platform}-${Constants.Hash}=false`),
-      "variable should be set to mark key as valid in build"
-    );
-
-    done();
-  });
-
-  it("RestoreCache runs successfully if cache miss for dot syntax keyfile", (done: MochaDone) => {
-    const tp = path.join(__dirname, "RestoreCacheCacheMissDotKeyFile.js");
-    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-    tr.run();
-
-    assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
-
-    assert(
-      tr.stdOutContained("Found key file: .commit"),
-      "should have found keyfile"
-    );
-
-    assert(
-      tr.stdOutContained("ArtifactTool.exe output"),
-      "should have ArtifactTool output"
-    );
-    assert(
-      tr.stdOutContained(`Cache miss:`),
-      "should have output stating cache miss"
-    );
-    assert(tr.succeeded, "should have succeeded");
-    assert.equal(tr.errorIssues.length, 0, "should have no errors");
-    assert(
-      tr.stdOutContained("set CacheRestored=false"),
-      "'CacheRestored' variable should be set to false"
-    );
-
-    done();
-  });
-
-  it("RestoreCache handles artifact permissions errors gracefully", (done: MochaDone) => {
-    const tp = path.join(__dirname, "RestoreCachePermissionsError.js");
-    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-    tr.run();
-
-    assert(tr.invokedToolCount === 1, "should have run ArtifactTool once");
-    assert(
-      tr.ran(
-        `/users/tmp/ArtifactTool.exe universal download --feed node-package-feed --service https://example.visualstudio.com/defaultcollection --package-name builddefinition1 --package-version 1.0.0-${
-          process.platform
-        }-${
-          Constants.Hash
-        } --path /users/home/directory/tmp_cache --patvar UNIVERSAL_DOWNLOAD_PAT --verbosity verbose`
-      ),
-      "it should have run ArtifactTool"
-    );
-    assert(
-      tr.stdOutContained("ArtifactTool.exe output"),
-      "should have ArtifactTool output"
-    );
-    assert(
-      tr.stdOutContained(
-        `Cache miss:  ${process.platform}-${Constants.Hash}`
-      ) !== true,
-      "should not have output stating cache miss"
-    );
-    assert(tr.succeeded, "should have succeeded");
-    assert.equal(tr.errorIssues.length, 0, "should have no errors");
-    assert(tr.warningIssues.length > 0, "should have permissions warnings");
-    assert(
-      tr.stdOutContained(
-        "warning;]Error: An unexpected error occurred while trying to download the package. Exit code(1) and error(An error occurred on the service. User lacks permission to complete this action.)"
-      ),
-      "There should be a warning about permissions"
-    );
-    assert(
-      tr.stdOutContained("warning;]Issue running universal packages tools"),
-      "There should be a warning about universal packages tools"
-    );
-    assert(
-      tr.stdOutContained("set CacheRestored=false") !== true,
-      "'CacheRestored' variable should not be set"
-    );
-    assert(
-      tr.stdOutContained(`${process.platform}-${Constants.Hash}=`) !== true,
-      "variable should not be set to mark key as valid in build"
-    );
-
-    done();
-  });
-
-  it("RestoreCache handles artifact tool download issues gracefully", (done: MochaDone) => {
-    const tp = path.join(__dirname, "RestoreCacheArtifactToolErr.js");
-    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-    tr.run();
-
-    assert(
-      tr.stdOutContained("Error initializing artifact tool"),
-      "should have error initializing artifact tool"
-    );
-    assert(tr.succeeded, "should have succeeded");
-    assert.equal(tr.errorIssues.length, 0, "should have no errors");
-    assert(tr.warningIssues.length > 0, "should have warnings");
-    assert(
-      tr.stdOutContained("set CacheRestored=") !== true,
-      "'CacheRestored' variable should not be set"
-    );
-    assert(
-      tr.stdOutContained(`set ${process.platform}-${Constants.Hash}=`) !== true,
-      "variable should not be set to mark key as valid in build"
-    );
-
-    done();
-  });
-});
-
-describe("SaveCache tests", function() {
-  before(function() {
-    process.env["SYSTEM_PULLREQUEST_ISFORK"] = "false";
-  });
-
-  after(() => {});
-
-  it("SaveCache runs successfully with warnings if no key files are found", function(done: MochaDone) {
-    const tp = path.join(__dirname, "SaveCacheNoKeyFiles.js");
-    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-    tr.run();
-
-    assert.equal(tr.succeeded, true, "should have succeeded");
-    assert.equal(
-      tr.warningIssues.length > 0,
-      true,
-      "should have warnings from key file"
-    );
-    assert.equal(tr.errorIssues.length, 0, "should have no errors");
-    assert.equal(
-      tr.stdout.indexOf("no key files matching:") >= 0,
-      true,
-      "should display 'no key files matching:'"
-    );
-
-    done();
-  });
-
-  it("SaveCache runs successfully with warnings if no target folders are found", function(done: MochaDone) {
-    const tp = path.join(__dirname, "SaveCacheNoTargetFolders.js");
-    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-    tr.run();
-
-    assert.equal(tr.succeeded, true, "should have succeeded");
-    assert.equal(
-      tr.warningIssues.length > 0,
-      true,
-      "should have warnings from target folder"
-    );
-    assert.equal(tr.errorIssues.length, 0, "should have no errors");
-    assert.equal(
-      tr.stdout.indexOf("no target folders matching:") >= 0,
-      true,
-      "should display 'no target folders matching:'"
-    );
-
-    done();
-  });
-
-  it("SaveCache is skipped if no run from repository fork", function(done: MochaDone) {
-    const tp = path.join(__dirname, "SaveCacheFromFork.js");
-    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-    tr.run();
-
-    assert.equal(tr.succeeded, true, "should have succeeded");
-    assert.equal(tr.warningIssues.length, 0, "should have no warnings");
-    assert.equal(tr.errorIssues.length, 0, "should have no errors");
-    assert.equal(
-      tr.stdout.indexOf("result=Skipped;") >= 0,
-      true,
-      "task result should be: 'Skipped'"
-    );
-    assert.equal(
-      tr.stdout.indexOf("Caches are not saved from forked repositories.") >= 0,
-      true,
-      "should display 'Caches are not saved from forked repositories.'"
-    );
-
-    done();
-  });
-
-  it("SaveCache doesn't create archive if cache hit", (done: MochaDone) => {
-    const tp = path.join(__dirname, "SaveCacheCacheHit.js");
-    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-    tr.run();
-
-    assert(
-      tr.stdOutContained("Cache entry already exists for:"),
-      "should have bailed out due to cache already present"
-    );
-    assert(tr.succeeded, "should have succeeded");
-    assert.equal(tr.errorIssues.length, 0, "should have no errors");
-
-    done();
-  });
-
-  it("SaveCache doesn't create an archive if no matching hash", (done: MochaDone) => {
-    const tp = path.join(__dirname, "SaveCacheNoHashMatch.js");
-    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-    tr.run();
-
-    assert(
-      tr.stdOutContained("Not caching artifact produced during build:"),
-      "should have bailed out due to no matching hash"
-    );
-    assert(
-      tr.stdOutContained("result=Skipped;"),
-      "task result should be: 'Skipped'"
-    );
-    assert(tr.succeeded, "should have succeeded");
-    assert.equal(tr.errorIssues.length, 0, "should have no errors");
-
-    done();
-  });
-
-  it("SaveCache handles artifact tool download issues gracefully", (done: MochaDone) => {
-    const tp = path.join(__dirname, "SaveCacheArtifactToolErr.js");
-    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-    tr.run();
-
-    assert(
-      tr.stdOutContained("Error initializing artifact tool"),
-      "should have error initializing artifact tool"
-    );
-    assert(tr.succeeded, "should have succeeded");
-    assert.equal(tr.errorIssues.length, 0, "should have no errors");
-    assert(tr.warningIssues.length > 0, "should have warnings");
-    assert(
-      tr.stdOutContained("set CacheRestored=") !== true,
-      "'CacheRestored' variable should not be set"
-    );
-    assert(
-      tr.stdOutContained(`set ${process.platform}-${Constants.Hash}=`) !== true,
-      "variable should not be set to mark key as valid in build"
-    );
-    assert(
-      tr.stdOutContained("Cache successfully saved") !== true,
-      "should not have saved new cache entry"
-    );
-
-    done();
-  });
-
-  it("SaveCache handles artifact permissions errors gracefully", (done: MochaDone) => {
-    const tp = path.join(__dirname, "SaveCachePermissionsError.js");
-    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-    tr.run();
-
-    assert(tr.succeeded, "should have succeeded");
-    assert.equal(tr.errorIssues.length, 0, "should have no errors");
-    assert(tr.warningIssues.length > 0, "should have warnings");
-    assert(
-      tr.stdOutContained(
-        "warning;]Issue saving package: Error: An unexpected error occurred while trying to push the package. Exit code(1) and error(An error occurred on the service. User lacks permission to complete this action.)"
-      ),
-      "There should be a warning about permissions"
-    );
-    assert(
-      tr.stdOutContained(
-        "warning;]Cache unsuccessfully saved. Find more information in logs above"
-      ),
-      "There should be a warning about cache not being saved"
-    );
-    assert(
-      tr.stdOutContained("Cache successfully saved") !== true,
-      "should not have saved new cache entry"
-    );
-
-    done();
-  });
-
-  it("SaveCache creates an archive if cache miss", (done: MochaDone) => {
-    const tp = path.join(__dirname, "SaveCacheCacheMiss.js");
-    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-    tr.run();
-
-    assert(
-      tr.stdOutContained("Cache successfully saved"),
-      "should have saved new cache entry"
-    );
-    assert(tr.succeeded, "should have succeeded");
-    assert.equal(tr.errorIssues.length, 0, "should have no errors");
-
-    done();
-  });
-
-  it("SaveCache creates an archive if cache miss for dot syntax keyfile", (done: MochaDone) => {
-    const tp = path.join(__dirname, "SaveCacheCacheMissDotKeyFile.js");
-    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-    tr.run();
-
-    assert(
-      tr.stdOutContained("Found key file: .commit"),
-      "should have found keyfile '.commit'"
-    );
-
-    assert(
-      tr.stdOutContained("Cache successfully saved"),
-      "should have saved new cache entry"
-    );
-    assert(tr.succeeded, "should have succeeded");
-    assert.equal(tr.errorIssues.length, 0, "should have no errors");
-
-    done();
-  });
-
-  it("SaveCache creates an archive if cache miss for dot target syntax folder patterns", (done: MochaDone) => {
-    const tp = path.join(__dirname, "SaveCacheCacheMissDotTarget.js");
-    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-    tr.run();
+    console.log(tr.stdout);
 
     assert(
       tr.stdOutContained("Found target folder: ../.build"),

--- a/Tasks/RestoreAndSaveCacheV1/package-lock.json
+++ b/Tasks/RestoreAndSaveCacheV1/package-lock.json
@@ -113,6 +113,22 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
+    "axios": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+        }
+      }
+    },
     "azure-devops-node-api": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.0.0.tgz",
@@ -721,6 +737,29 @@
         }
       }
     },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -892,13 +931,20 @@
       "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
     },
     "ip-address": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-5.9.2.tgz",
-      "integrity": "sha512-7aeFm/7oqo0mMhubTSjZ2Juw/F+WJ3hyfCScNVRQdz5RSRhw1Rj4ZlBFsmEajeKgQDI8asqVs31h8DpxEv7IfQ==",
+      "version": "5.9.4",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-5.9.4.tgz",
+      "integrity": "sha512-dHkI3/YNJq4b/qQaz+c8LuarD3pY24JqZWfjB8aZx1gtpc2MDILu9L9jpZe1sHpzo/yWFweQVn+U//FhazUxmw==",
       "requires": {
         "jsbn": "1.1.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "sprintf-js": "1.1.2"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "is-accessor-descriptor": {
@@ -1109,11 +1155,18 @@
       }
     },
     "ltx": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.8.1.tgz",
-      "integrity": "sha512-l4H1FS9I6IVqwvIpUHsSgyxE6t2jP7qd/2MeVG1UhmVK6vlHsQpfm2KNUcbdImeE0ai04vl1qTCF4CPCJqhknQ==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.9.2.tgz",
+      "integrity": "sha512-llB7HflFhlfsYYT1SAe80elCBO5C20ryLdwPB/A/BZk38hhVeZztDlWQ9uTyvKNPX4aK6sA+JfS1f/mfzp5cxA==",
       "requires": {
-        "inherits": "^2.0.1"
+        "inherits": "^2.0.4"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        }
       }
     },
     "make-error": {
@@ -1435,6 +1488,7 @@
         "@types/ltx": "^2.8.0",
         "@types/node": "^11.13.0",
         "adm-zip": "^0.4.11",
+        "axios": "^0.19.0",
         "azure-devops-node-api": "^6.6.0",
         "azure-pipelines-task-lib": "^2.8.0",
         "azure-pipelines-tool-lib": "^0.12.0",
@@ -1448,9 +1502,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "11.13.17",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.17.tgz",
-          "integrity": "sha512-7W3kSMa8diVH6s24a8Qrmvwu+vG3ahOC/flMHFdWSdnPYoQI0yPO84h5zOWYXAha2Npn3Pw3SSuQSwBUfaniyQ=="
+          "version": "11.15.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.2.tgz",
+          "integrity": "sha512-BqCU9uIFkUH9Sgo2uLYbmIiFB1T+VBiM8AI/El3LIAI5KzwtckeSG+3WOYZr9aMoX4UIvRFBWBeSaOu6hFue2Q=="
         },
         "azure-devops-node-api": {
           "version": "6.6.3",

--- a/Tasks/RestoreAndSaveCacheV1/package-lock.json
+++ b/Tasks/RestoreAndSaveCacheV1/package-lock.json
@@ -129,6 +129,14 @@
         }
       }
     },
+    "axios-mock-adapter": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.17.0.tgz",
+      "integrity": "sha512-q3efmwJUOO4g+wsLNSk9Ps1UlJoF3fQ3FSEe4uEEhkRtu7SoiAVPj8R3Hc/WP55MBTVFzaDP9QkdJhdVhP8A1Q==",
+      "requires": {
+        "deep-equal": "^1.0.1"
+      }
+    },
     "azure-devops-node-api": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.0.0.tgz",
@@ -440,6 +448,26 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
+    "deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.0.tgz",
+      "integrity": "sha512-ZbfWJq/wN1Z273o7mUSjILYqehAktR2NVoSrOukDkU9kg2v/Uv89yU4Cvz8seJeAmtN5oqiefKq8FPuXOboqLw==",
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      },
+      "dependencies": {
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+        }
+      }
     },
     "define-properties": {
       "version": "1.1.3",
@@ -965,6 +993,11 @@
         }
       }
     },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
+    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
@@ -1382,6 +1415,11 @@
         }
       }
     },
+    "object-is": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
+      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
+    },
     "object-keys": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
@@ -1489,6 +1527,7 @@
         "@types/node": "^11.13.0",
         "adm-zip": "^0.4.11",
         "axios": "^0.19.0",
+        "axios-mock-adapter": "^1.17.0",
         "azure-devops-node-api": "^6.6.0",
         "azure-pipelines-task-lib": "^2.8.0",
         "azure-pipelines-tool-lib": "^0.12.0",
@@ -1594,6 +1633,14 @@
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
+      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+      "requires": {
+        "define-properties": "^1.1.2"
       }
     },
     "repeat-element": {

--- a/Tasks/RestoreAndSaveCacheV1/task.json
+++ b/Tasks/RestoreAndSaveCacheV1/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 15
+    "Patch": 18
   },
   "instanceNameFormat": "Restore and save artifact based on: $(keyfile)",
   "inputs": [

--- a/Tasks/RestoreAndSaveCacheV1/task.json
+++ b/Tasks/RestoreAndSaveCacheV1/task.json
@@ -46,6 +46,14 @@
       "required": "false"
     },
     {
+      "name": "dryRun",
+      "type": "boolean",
+      "label": "Dry run",
+      "description": "Check if the cache exists, without downloading it (default is false).",
+      "defaultValue": false,
+      "required": "false"
+    },
+    {
       "name": "alias",
       "type": "string",
       "label": "Cache alias",

--- a/Tasks/RestoreAndSaveCacheV1/task.loc.json
+++ b/Tasks/RestoreAndSaveCacheV1/task.loc.json
@@ -48,6 +48,14 @@
       "required": "false"
     },
     {
+      "name": "dryRun",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.dryRun",
+      "description": "Check if the cache exists, without downloading it (default is false).",
+      "defaultValue": false,
+      "required": "false"
+    },
+    {
       "name": "alias",
       "type": "string",
       "label": "ms-resource:loc.input.label.alias",

--- a/Tasks/RestoreAndSaveCacheV1/task.loc.json
+++ b/Tasks/RestoreAndSaveCacheV1/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 15
+    "Patch": 18
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "inputs": [

--- a/Tasks/RestoreCacheV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/RestoreCacheV1/Strings/resources.resjson/en-US/resources.resjson
@@ -9,6 +9,7 @@
   "loc.input.help.targetfolder": "The folder/file or wildcard of items to cache. For example, node projects can cache packages with '**/node_modules, !**/node_modules/**/node_modules'.",
   "loc.input.label.feedList": "Feed",
   "loc.input.label.platformIndependent": "Platform Independent?",
+  "loc.input.label.dryRun": "Dry run",
   "loc.input.label.alias": "Cache alias",
   "loc.input.label.verbosity": "Verbosity",
   "loc.input.help.verbosity": "Specifies the amount of detail displayed in the output.",

--- a/Tasks/RestoreCacheV1/package-lock.json
+++ b/Tasks/RestoreCacheV1/package-lock.json
@@ -408,9 +408,9 @@
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "ts-node": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.4.1.tgz",
-      "integrity": "sha512-5LpRN+mTiCs7lI5EtbXmF/HfMeCjzt7DH9CZwtkr6SywStrNQC723wG+aOWFiLNn7zT3kD/RnFqi3ZUfr4l5Qw==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.0.tgz",
+      "integrity": "sha512-fbG32iZEupNV2E2Fd2m2yt1TdAwR3GTCrJQBHDevIiEBNy1A8kqnyl1fv7jmRmmbtcapFab2glZXHJvfD1ed0Q==",
       "requires": {
         "arg": "^4.1.0",
         "diff": "^4.0.1",

--- a/Tasks/RestoreCacheV1/package-lock.json
+++ b/Tasks/RestoreCacheV1/package-lock.json
@@ -59,6 +59,14 @@
         "is-buffer": "^2.0.2"
       }
     },
+    "axios-mock-adapter": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.17.0.tgz",
+      "integrity": "sha512-q3efmwJUOO4g+wsLNSk9Ps1UlJoF3fQ3FSEe4uEEhkRtu7SoiAVPj8R3Hc/WP55MBTVFzaDP9QkdJhdVhP8A1Q==",
+      "requires": {
+        "deep-equal": "^1.0.1"
+      }
+    },
     "azure-devops-node-api": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.0.0.tgz",
@@ -158,6 +166,27 @@
         "ms": "2.0.0"
       }
     },
+    "deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.0.tgz",
+      "integrity": "sha512-ZbfWJq/wN1Z273o7mUSjILYqehAktR2NVoSrOukDkU9kg2v/Uv89yU4Cvz8seJeAmtN5oqiefKq8FPuXOboqLw==",
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
     "diff": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
@@ -176,6 +205,11 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
     "glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -187,6 +221,14 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
       }
     },
     "inflight": {
@@ -223,10 +265,28 @@
         "sprintf-js": "1.1.2"
       }
     },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
+    },
     "is-buffer": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
       "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "requires": {
+        "has": "^1.0.1"
+      }
     },
     "jsbn": {
       "version": "1.1.0",
@@ -276,6 +336,16 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "object-is": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
+      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -296,6 +366,7 @@
         "@types/node": "^11.13.0",
         "adm-zip": "^0.4.11",
         "axios": "^0.19.0",
+        "axios-mock-adapter": "^1.17.0",
         "azure-devops-node-api": "^6.6.0",
         "azure-pipelines-task-lib": "^2.8.0",
         "azure-pipelines-tool-lib": "^0.12.0",
@@ -358,6 +429,14 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
         "resolve": "^1.1.6"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
+      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+      "requires": {
+        "define-properties": "^1.1.2"
       }
     },
     "resolve": {

--- a/Tasks/RestoreCacheV1/package-lock.json
+++ b/Tasks/RestoreCacheV1/package-lock.json
@@ -46,9 +46,18 @@
       "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw=="
     },
     "arg": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
-      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.1.tgz",
+      "integrity": "sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw=="
+    },
+    "axios": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      }
     },
     "azure-devops-node-api": {
       "version": "7.0.0",
@@ -141,10 +150,26 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
     "diff": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
       "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q=="
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -189,14 +214,19 @@
       "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
     },
     "ip-address": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-5.9.2.tgz",
-      "integrity": "sha512-7aeFm/7oqo0mMhubTSjZ2Juw/F+WJ3hyfCScNVRQdz5RSRhw1Rj4ZlBFsmEajeKgQDI8asqVs31h8DpxEv7IfQ==",
+      "version": "5.9.4",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-5.9.4.tgz",
+      "integrity": "sha512-dHkI3/YNJq4b/qQaz+c8LuarD3pY24JqZWfjB8aZx1gtpc2MDILu9L9jpZe1sHpzo/yWFweQVn+U//FhazUxmw==",
       "requires": {
         "jsbn": "1.1.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "sprintf-js": "1.1.2"
       }
+    },
+    "is-buffer": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
     },
     "jsbn": {
       "version": "1.1.0",
@@ -204,16 +234,23 @@
       "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
     },
     "lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "ltx": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.8.1.tgz",
-      "integrity": "sha512-l4H1FS9I6IVqwvIpUHsSgyxE6t2jP7qd/2MeVG1UhmVK6vlHsQpfm2KNUcbdImeE0ai04vl1qTCF4CPCJqhknQ==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.9.2.tgz",
+      "integrity": "sha512-llB7HflFhlfsYYT1SAe80elCBO5C20ryLdwPB/A/BZk38hhVeZztDlWQ9uTyvKNPX4aK6sA+JfS1f/mfzp5cxA==",
       "requires": {
-        "inherits": "^2.0.1"
+        "inherits": "^2.0.4"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        }
       }
     },
     "make-error": {
@@ -234,6 +271,11 @@
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
     },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -253,6 +295,7 @@
         "@types/ltx": "^2.8.0",
         "@types/node": "^11.13.0",
         "adm-zip": "^0.4.11",
+        "axios": "^0.19.0",
         "azure-devops-node-api": "^6.6.0",
         "azure-pipelines-task-lib": "^2.8.0",
         "azure-pipelines-tool-lib": "^0.12.0",
@@ -266,9 +309,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "11.13.17",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.17.tgz",
-          "integrity": "sha512-7W3kSMa8diVH6s24a8Qrmvwu+vG3ahOC/flMHFdWSdnPYoQI0yPO84h5zOWYXAha2Npn3Pw3SSuQSwBUfaniyQ=="
+          "version": "11.15.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.2.tgz",
+          "integrity": "sha512-BqCU9uIFkUH9Sgo2uLYbmIiFB1T+VBiM8AI/El3LIAI5KzwtckeSG+3WOYZr9aMoX4UIvRFBWBeSaOu6hFue2Q=="
         },
         "azure-devops-node-api": {
           "version": "6.6.3",
@@ -351,9 +394,9 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-support": {
-      "version": "0.5.12",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
-      "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+      "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -365,9 +408,9 @@
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "ts-node": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.3.0.tgz",
-      "integrity": "sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.4.1.tgz",
+      "integrity": "sha512-5LpRN+mTiCs7lI5EtbXmF/HfMeCjzt7DH9CZwtkr6SywStrNQC723wG+aOWFiLNn7zT3kD/RnFqi3ZUfr4l5Qw==",
       "requires": {
         "arg": "^4.1.0",
         "diff": "^4.0.1",
@@ -406,9 +449,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "yn": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.0.tgz",
-      "integrity": "sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     }
   }
 }

--- a/Tasks/RestoreCacheV1/task.json
+++ b/Tasks/RestoreCacheV1/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 15
+    "Patch": 18
   },
   "instanceNameFormat": "Restore artifact based on: $(keyfile)",
   "inputs": [

--- a/Tasks/RestoreCacheV1/task.json
+++ b/Tasks/RestoreCacheV1/task.json
@@ -46,6 +46,14 @@
       "required": "false"
     },
     {
+      "name": "dryRun",
+      "type": "boolean",
+      "label": "Dry run",
+      "description": "Check if the cache exists, without downloading it (default is false).",
+      "defaultValue": false,
+      "required": "false"
+    },
+    {
       "name": "alias",
       "type": "string",
       "label": "Cache alias",

--- a/Tasks/RestoreCacheV1/task.loc.json
+++ b/Tasks/RestoreCacheV1/task.loc.json
@@ -48,6 +48,14 @@
       "required": "false"
     },
     {
+      "name": "dryRun",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.dryRun",
+      "description": "Check if the cache exists, without downloading it (default is false).",
+      "defaultValue": false,
+      "required": "false"
+    },
+    {
       "name": "alias",
       "type": "string",
       "label": "ms-resource:loc.input.label.alias",

--- a/Tasks/RestoreCacheV1/task.loc.json
+++ b/Tasks/RestoreCacheV1/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 15
+    "Patch": 18
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "inputs": [

--- a/Tasks/SaveCacheV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/SaveCacheV1/Strings/resources.resjson/en-US/resources.resjson
@@ -9,6 +9,7 @@
   "loc.input.help.targetfolder": "The folder/file or wildcard of items to cache. For example, node projects can cache packages with '**/node_modules, !**/node_modules/**/node_modules'.",
   "loc.input.label.feedList": "Feed",
   "loc.input.label.platformIndependent": "Platform Independent?",
+  "loc.input.label.dryRun": "Dry run",
   "loc.input.label.alias": "Cache alias",
   "loc.input.label.verbosity": "Verbosity",
   "loc.input.help.verbosity": "Specifies the amount of detail displayed in the output.",

--- a/Tasks/SaveCacheV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/SaveCacheV1/Strings/resources.resjson/en-US/resources.resjson
@@ -9,7 +9,6 @@
   "loc.input.help.targetfolder": "The folder/file or wildcard of items to cache. For example, node projects can cache packages with '**/node_modules, !**/node_modules/**/node_modules'.",
   "loc.input.label.feedList": "Feed",
   "loc.input.label.platformIndependent": "Platform Independent?",
-  "loc.input.label.dryRun": "Dry run",
   "loc.input.label.alias": "Cache alias",
   "loc.input.label.verbosity": "Verbosity",
   "loc.input.help.verbosity": "Specifies the amount of detail displayed in the output.",

--- a/Tasks/SaveCacheV1/package-lock.json
+++ b/Tasks/SaveCacheV1/package-lock.json
@@ -408,9 +408,9 @@
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "ts-node": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.4.1.tgz",
-      "integrity": "sha512-5LpRN+mTiCs7lI5EtbXmF/HfMeCjzt7DH9CZwtkr6SywStrNQC723wG+aOWFiLNn7zT3kD/RnFqi3ZUfr4l5Qw==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.0.tgz",
+      "integrity": "sha512-fbG32iZEupNV2E2Fd2m2yt1TdAwR3GTCrJQBHDevIiEBNy1A8kqnyl1fv7jmRmmbtcapFab2glZXHJvfD1ed0Q==",
       "requires": {
         "arg": "^4.1.0",
         "diff": "^4.0.1",

--- a/Tasks/SaveCacheV1/package-lock.json
+++ b/Tasks/SaveCacheV1/package-lock.json
@@ -59,6 +59,14 @@
         "is-buffer": "^2.0.2"
       }
     },
+    "axios-mock-adapter": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.17.0.tgz",
+      "integrity": "sha512-q3efmwJUOO4g+wsLNSk9Ps1UlJoF3fQ3FSEe4uEEhkRtu7SoiAVPj8R3Hc/WP55MBTVFzaDP9QkdJhdVhP8A1Q==",
+      "requires": {
+        "deep-equal": "^1.0.1"
+      }
+    },
     "azure-devops-node-api": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.0.0.tgz",
@@ -158,6 +166,27 @@
         "ms": "2.0.0"
       }
     },
+    "deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.0.tgz",
+      "integrity": "sha512-ZbfWJq/wN1Z273o7mUSjILYqehAktR2NVoSrOukDkU9kg2v/Uv89yU4Cvz8seJeAmtN5oqiefKq8FPuXOboqLw==",
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
     "diff": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
@@ -176,6 +205,11 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
     "glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -187,6 +221,14 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
       }
     },
     "inflight": {
@@ -223,10 +265,28 @@
         "sprintf-js": "1.1.2"
       }
     },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
+    },
     "is-buffer": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
       "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "requires": {
+        "has": "^1.0.1"
+      }
     },
     "jsbn": {
       "version": "1.1.0",
@@ -276,6 +336,16 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "object-is": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
+      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -296,6 +366,7 @@
         "@types/node": "^11.13.0",
         "adm-zip": "^0.4.11",
         "axios": "^0.19.0",
+        "axios-mock-adapter": "^1.17.0",
         "azure-devops-node-api": "^6.6.0",
         "azure-pipelines-task-lib": "^2.8.0",
         "azure-pipelines-tool-lib": "^0.12.0",
@@ -358,6 +429,14 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
         "resolve": "^1.1.6"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
+      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+      "requires": {
+        "define-properties": "^1.1.2"
       }
     },
     "resolve": {

--- a/Tasks/SaveCacheV1/package-lock.json
+++ b/Tasks/SaveCacheV1/package-lock.json
@@ -46,9 +46,18 @@
       "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw=="
     },
     "arg": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
-      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.1.tgz",
+      "integrity": "sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw=="
+    },
+    "axios": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      }
     },
     "azure-devops-node-api": {
       "version": "7.0.0",
@@ -141,10 +150,26 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
     "diff": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
       "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q=="
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -189,14 +214,19 @@
       "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
     },
     "ip-address": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-5.9.2.tgz",
-      "integrity": "sha512-7aeFm/7oqo0mMhubTSjZ2Juw/F+WJ3hyfCScNVRQdz5RSRhw1Rj4ZlBFsmEajeKgQDI8asqVs31h8DpxEv7IfQ==",
+      "version": "5.9.4",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-5.9.4.tgz",
+      "integrity": "sha512-dHkI3/YNJq4b/qQaz+c8LuarD3pY24JqZWfjB8aZx1gtpc2MDILu9L9jpZe1sHpzo/yWFweQVn+U//FhazUxmw==",
       "requires": {
         "jsbn": "1.1.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "sprintf-js": "1.1.2"
       }
+    },
+    "is-buffer": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
     },
     "jsbn": {
       "version": "1.1.0",
@@ -204,16 +234,23 @@
       "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
     },
     "lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "ltx": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.8.1.tgz",
-      "integrity": "sha512-l4H1FS9I6IVqwvIpUHsSgyxE6t2jP7qd/2MeVG1UhmVK6vlHsQpfm2KNUcbdImeE0ai04vl1qTCF4CPCJqhknQ==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.9.2.tgz",
+      "integrity": "sha512-llB7HflFhlfsYYT1SAe80elCBO5C20ryLdwPB/A/BZk38hhVeZztDlWQ9uTyvKNPX4aK6sA+JfS1f/mfzp5cxA==",
       "requires": {
-        "inherits": "^2.0.1"
+        "inherits": "^2.0.4"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        }
       }
     },
     "make-error": {
@@ -234,6 +271,11 @@
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
     },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -253,6 +295,7 @@
         "@types/ltx": "^2.8.0",
         "@types/node": "^11.13.0",
         "adm-zip": "^0.4.11",
+        "axios": "^0.19.0",
         "azure-devops-node-api": "^6.6.0",
         "azure-pipelines-task-lib": "^2.8.0",
         "azure-pipelines-tool-lib": "^0.12.0",
@@ -266,9 +309,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "11.13.17",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.17.tgz",
-          "integrity": "sha512-7W3kSMa8diVH6s24a8Qrmvwu+vG3ahOC/flMHFdWSdnPYoQI0yPO84h5zOWYXAha2Npn3Pw3SSuQSwBUfaniyQ=="
+          "version": "11.15.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.2.tgz",
+          "integrity": "sha512-BqCU9uIFkUH9Sgo2uLYbmIiFB1T+VBiM8AI/El3LIAI5KzwtckeSG+3WOYZr9aMoX4UIvRFBWBeSaOu6hFue2Q=="
         },
         "azure-devops-node-api": {
           "version": "6.6.3",
@@ -351,9 +394,9 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-support": {
-      "version": "0.5.12",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
-      "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+      "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -365,9 +408,9 @@
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "ts-node": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.3.0.tgz",
-      "integrity": "sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.4.1.tgz",
+      "integrity": "sha512-5LpRN+mTiCs7lI5EtbXmF/HfMeCjzt7DH9CZwtkr6SywStrNQC723wG+aOWFiLNn7zT3kD/RnFqi3ZUfr4l5Qw==",
       "requires": {
         "arg": "^4.1.0",
         "diff": "^4.0.1",
@@ -406,9 +449,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "yn": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.0.tgz",
-      "integrity": "sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     }
   }
 }

--- a/Tasks/SaveCacheV1/task.json
+++ b/Tasks/SaveCacheV1/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 15
+    "Patch": 18
   },
   "instanceNameFormat": "Save artifact based on: $(keyfile)",
   "inputs": [
@@ -42,14 +42,6 @@
       "type": "boolean",
       "label": "Platform Independent?",
       "description": "Whether the cached artifact is platform independent (default is false).",
-      "defaultValue": false,
-      "required": "false"
-    },
-    {
-      "name": "dryRun",
-      "type": "boolean",
-      "label": "Dry run",
-      "description": "Check if the cache exists, without downloading it (default is false).",
       "defaultValue": false,
       "required": "false"
     },

--- a/Tasks/SaveCacheV1/task.json
+++ b/Tasks/SaveCacheV1/task.json
@@ -46,6 +46,14 @@
       "required": "false"
     },
     {
+      "name": "dryRun",
+      "type": "boolean",
+      "label": "Dry run",
+      "description": "Check if the cache exists, without downloading it (default is false).",
+      "defaultValue": false,
+      "required": "false"
+    },
+    {
       "name": "alias",
       "type": "string",
       "label": "Cache alias",

--- a/Tasks/SaveCacheV1/task.loc.json
+++ b/Tasks/SaveCacheV1/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 15
+    "Patch": 18
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "inputs": [
@@ -44,14 +44,6 @@
       "type": "boolean",
       "label": "ms-resource:loc.input.label.platformIndependent",
       "description": "Whether the cached artifact is platform independent (default is false).",
-      "defaultValue": false,
-      "required": "false"
-    },
-    {
-      "name": "dryRun",
-      "type": "boolean",
-      "label": "ms-resource:loc.input.label.dryRun",
-      "description": "Check if the cache exists, without downloading it (default is false).",
       "defaultValue": false,
       "required": "false"
     },

--- a/Tasks/SaveCacheV1/task.loc.json
+++ b/Tasks/SaveCacheV1/task.loc.json
@@ -48,6 +48,14 @@
       "required": "false"
     },
     {
+      "name": "dryRun",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.dryRun",
+      "description": "Check if the cache exists, without downloading it (default is false).",
+      "defaultValue": false,
+      "required": "false"
+    },
+    {
       "name": "alias",
       "type": "string",
       "label": "ms-resource:loc.input.label.alias",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/mocha": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.6.tgz",
-      "integrity": "sha512-1axi39YdtBI7z957vdqXI4Ac25e7YihYQtJa+Clnxg1zTJEaIRbndt71O3sP4GAMgiAm0pY26/b9BrY4MR/PMw==",
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+      "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
       "dev": true
     },
     "@types/node": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/Microsoft/azure-pipelines-artifact-caching-tasks",
   "devDependencies": {
-    "@types/mocha": "^5.2.6",
+    "@types/mocha": "^5.2.7",
     "@types/node": "^11.13.0",
     "gulp": "^3.9.1",
     "gulp-util": "3.0.4",


### PR DESCRIPTION
This adds a dryRun parameter to `RestoreCache` and `RestoreAndSaveCache` to simply check if the cache exists. A `CacheExists(-alias)` env variable will be emitted with the result. This can be used like so:
```yaml
  - task: 1eslighthouseeng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
    inputs:
      keyfile: '**/yarn.lock, !**/node_modules/**/yarn.lock, !**/.*/**/yarn.lock'
      targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
      vstsFeed: '$(ArtifactFeed)'
      dryRun: true
  - script: |
      yarn --frozen-lockfile
    displayName: Install Dependencies
    condition: ne(variables['CacheRestored'], 'true')
  - task: 1eslighthouseeng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1
    inputs:
      keyfile: '**/yarn.lock, !**/node_modules/**/yarn.lock, !**/.*/**/yarn.lock'
      targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
      vstsFeed: '$(ArtifactFeed)'
    condition: and(succeeded(), ne(variables['CacheExists'], 'true'))
``` 