### PR TITLE
Pipeline name can contain characters not allowed for package id

### DIFF
--- a/Tasks/Common/packaging-common/cache/feedUtilities.ts
+++ b/Tasks/Common/packaging-common/cache/feedUtilities.ts
@@ -13,7 +13,7 @@ export async function doesPackageExist(hash: string): Promise<boolean> {
   // Getting package name from hash
   const packageId = tl
     .getVariable("Build.DefinitionName")
-    .replace(/\s/g, "")
+    .replace(/[^a-z0-9\-]/g, "")
     .substring(0, 255)
     .toLowerCase();
 

--- a/Tasks/Common/packaging-common/cache/universaldownload.ts
+++ b/Tasks/Common/packaging-common/cache/universaldownload.ts
@@ -35,7 +35,7 @@ export async function run(artifactToolPath: string, hash: string, targetFolder: 
 
         // Getting package name from hash
         const packageId = tl.getVariable('Build.DefinitionName')
-            .replace(/\s/g, "")
+            .replace(/[^a-z0-9\-]/g, "")
             .substring(0, 255)
             .toLowerCase();
 

--- a/Tasks/Common/packaging-common/cache/universalpublish.ts
+++ b/Tasks/Common/packaging-common/cache/universalpublish.ts
@@ -35,7 +35,7 @@ export async function run(artifactToolPath: string, hash: string, targetFolder: 
         serviceUri = tl.getEndpointUrl("SYSTEMVSSCONNECTION", false);
 
         packageName = tl.getVariable('Build.DefinitionName')
-            .replace(/\s/g, "")
+            .replace(/[^a-z0-9\-]/g, "")
             .substring(0, 255)
             .toLowerCase();
 


### PR DESCRIPTION
After investigating why this task would not work I realized it was because of characters not allowed.

The problem lies in that pipeline names, which are defined as `Build.DefinitionName` in the pipeline, have a more relaxed set of rules of allowed characters than package ids for the universal package feed.

There's already a regular expression removing empty space, but that is not enough.

Since it is not possible to apply your own name for the package id in the task input, this works a quick fix removing all the characters not allowed in the package id according to [Azure DevOps documentation](https://docs.microsoft.com/en-us/azure/devops/artifacts/quickstarts/universal-packages?view=azure-devops&tabs=azuredevops#publish-a-universal-package).